### PR TITLE
fix(gtm-setup): block private tunnel source links

### DIFF
--- a/skills/gtm-setup/scripts/classify_context_links.py
+++ b/skills/gtm-setup/scripts/classify_context_links.py
@@ -32,6 +32,15 @@ PRIVATE_HOST_MARKERS = {
     "notion.so",
     "salesforce.com",
 }
+PRIVATE_TUNNEL_HOST_SUFFIXES = {
+    "loca.lt",
+    "localtunnel.me",
+    "ngrok-free.app",
+    "ngrok.app",
+    "ngrok.dev",
+    "ngrok.io",
+    "trycloudflare.com",
+}
 LOCAL_HOSTS = {"localhost", "127.0.0.1", "0.0.0.0", "::1"}
 
 
@@ -84,6 +93,8 @@ def _unsafe_reason(parsed, host: str, netloc: str, path: str, query_keys: set[st
         return "embedded credentials"
     if host in LOCAL_HOSTS or host.endswith(".local") or "localhost" in netloc:
         return "local-only URL"
+    if _has_host_suffix(host, PRIVATE_TUNNEL_HOST_SUFFIXES):
+        return "private-tunnel URL"
     if "/invite" in path or "invite" in path.split("/"):
         return "invite URL"
     if SECRET_QUERY_KEYS & query_keys:
@@ -91,6 +102,10 @@ def _unsafe_reason(parsed, host: str, netloc: str, path: str, query_keys: set[st
     if any("token" in key or "signature" in key for key in query_keys):
         return "secret-bearing or tokenized query parameter"
     return None
+
+
+def _has_host_suffix(host: str, suffixes: set[str]) -> bool:
+    return any(host == suffix or host.endswith(f".{suffix}") for suffix in suffixes)
 
 
 def _private_reason(host: str, netloc: str) -> str | None:
@@ -104,6 +119,8 @@ def _private_reason(host: str, netloc: str) -> str | None:
 def _safe_label_for_unsafe(reason: str) -> str:
     if reason == "local-only URL":
         return "Local-only source used during setup. Link not committed."
+    if reason == "private-tunnel URL":
+        return "Private tunnel source used during setup. Link not committed."
     if reason == "invite URL":
         return "Invite link provided during setup. Link not committed."
     return "Sensitive source used during setup. Link not committed."

--- a/skills/gtm-setup/scripts/test_classify_context_links.py
+++ b/skills/gtm-setup/scripts/test_classify_context_links.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Regression tests for the GTM setup source-link classifier."""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from classify_context_links import classify_link
+
+
+class ClassifyContextLinksTests(unittest.TestCase):
+    def test_public_link_is_saved_after_confirmation(self) -> None:
+        result = classify_link("https://example.com/acme")
+
+        self.assertEqual(result.classification, "public")
+        self.assertEqual(result.commit_behavior, "save_after_confirmation")
+        self.assertIsNone(result.safe_label)
+
+    def test_tokenized_link_is_never_committed(self) -> None:
+        result = classify_link("https://app.hubspot.com/contacts/123?token=secret")
+
+        self.assertEqual(result.classification, "unsafe")
+        self.assertEqual(result.commit_behavior, "never_commit")
+        self.assertEqual(result.reason, "secret-bearing or tokenized query parameter")
+        self.assertEqual(
+            result.safe_label,
+            "Sensitive source used during setup. Link not committed.",
+        )
+
+    def test_localhost_link_is_never_committed(self) -> None:
+        result = classify_link("http://localhost:3000/debug")
+
+        self.assertEqual(result.classification, "unsafe")
+        self.assertEqual(result.commit_behavior, "never_commit")
+        self.assertEqual(result.reason, "local-only URL")
+        self.assertEqual(
+            result.safe_label,
+            "Local-only source used during setup. Link not committed.",
+        )
+
+    def test_private_tunnel_link_is_never_committed(self) -> None:
+        result = classify_link("https://foo.ngrok.app/path")
+
+        self.assertEqual(result.classification, "unsafe")
+        self.assertEqual(result.commit_behavior, "never_commit")
+        self.assertEqual(result.reason, "private-tunnel URL")
+        self.assertEqual(
+            result.safe_label,
+            "Private tunnel source used during setup. Link not committed.",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

GTM setup now treats common private tunnel URLs as unsafe setup sources instead of public links. A sample like `https://foo.ngrok.app/path` now returns `unsafe` / `never_commit` with a safe non-sensitive label, while public links, tokenized URLs, and localhost URLs keep their existing classifications.

Related: Paperclip ELI-188

## Validation

- `python3 -m unittest skills/gtm-setup/scripts/test_classify_context_links.py` -> 4 tests pass
- `python3 -m py_compile skills/gtm-setup/scripts/classify_context_links.py skills/gtm-setup/scripts/test_classify_context_links.py` -> pass
- CLI smoke check with public, tokenized HubSpot, localhost, and `foo.ngrok.app` samples -> expected JSON classifications
- `git diff --check` -> pass

## Post-Deploy Monitoring & Validation

No additional production monitoring required; this is a local classifier script shipped with the skill. Post-merge validation owner: CTO. Re-run the focused unittest and the CLI smoke sample after installing the skill copy; failure signal is any private tunnel sample returning `public` or any token/local sample changing away from `unsafe` / `never_commit`.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex GPT-5](https://img.shields.io/badge/Codex_GPT--5-000000)
