### PR TITLE
Replace Decision primitive with Switch

### DIFF
--- a/skills/gtm-setup/SKILL.md
+++ b/skills/gtm-setup/SKILL.md
@@ -5,7 +5,7 @@ description: Set up, register, switch, validate, or extend a fractal GTM context
 
 # GTM Setup
 
-## Decision
+## Switch
 
 | Condition | Action |
 | --- | --- |


### PR DESCRIPTION
## What changed

- Renamed the `gtm-setup` core primitive heading from `Decision` to `Switch`.
- Kept the existing condition/action table unchanged because it already matches the mandated Switch form.

## Why

`Decision` is not a primitive in the current `/skill-issue` vocabulary. `Switch` is the correct primitive for observable conditions that select actions while the skill retains ownership.

## Impact

The active GTM skill set now uses only recognized core primitives and `gtm-setup` remains behaviorally unchanged.

## Validation

- Manual frontmatter, primitive-count, and line-budget validation for all nine skills
- Confirmed no `## Decision` heading remains in active `skills/**/SKILL.md` files
- `git diff --check`

The `agentskills` executable was not installed locally, so the documented manual validation fallback was used.