### PR TITLE
Match public README formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,16 @@
-<p align="center">
-  <img src="https://img.shields.io/badge/GTM%20Skills-Open%20source%20skills%20for%20GTM-2ea44f?style=flat-square&labelColor=24292f" alt="GTM Skills — Open source skills for GTM" />
-</p>
+<p align="center"><img src="https://img.shields.io/badge/GTM%20Skills-Open%20source%20skills%20for%20GTM-2ea44f?style=flat-square&labelColor=24292f" alt="GTM Skills — Open source skills for GTM" /></p>
 
 <h3 align="center">Run your full GTM motion from one shared context</h3>
 
-<p align="center">
-  GTM Skills lets your team define the market, qualify accounts and leads, and research the next move when one-off prompts keep losing the rules, by connecting nine open source skills to one Git-backed GTM context.
-</p>
+<p align="center">GTM Skills lets your team define the market, qualify accounts and leads, and research the next move when one-off prompts keep losing the rules, by connecting nine open source skills to one Git-backed GTM context.</p>
 
-<p align="center">
-  <img src="assets/gtm-skills-flow.svg" width="88%" alt="GTM Skills turns one GTM context into the next qualified action" />
-</p>
+<p align="center"><img src="assets/gtm-skills-flow.svg" width="88%" alt="GTM Skills turns one GTM context into the next qualified action" /></p>
 
-<p align="center">
-  <a href="https://github.com/eliasstravik/gtmskills/blob/main/docs/getting-started.md"><img src="assets/buttons/install-gtm-skills.svg" alt="Install GTM Skills" /></a>
-  &nbsp;
-  <a href="https://cal.com/stravik/demo?projects=GTM%20Skills"><img src="assets/buttons/book-a-demo.svg" alt="Book a demo" /></a>
-</p>
+<p align="center"><a href="https://github.com/eliasstravik/gtmskills/blob/main/docs/getting-started.md"><img src="assets/buttons/install-gtm-skills.svg" alt="Install GTM Skills" /></a>&nbsp;&nbsp;<a href="https://cal.com/stravik/demo?projects=GTM%20Skills" target="_blank" rel="noopener noreferrer"><img src="assets/buttons/book-a-demo.svg" alt="Book a demo" /></a></p>
 
-<p align="center">
-  ✓ 100% free and open source &nbsp;&nbsp; ✓ Nine GTM skills, one install &nbsp;&nbsp; ✓ Built for the full GTM motion
-</p>
+<p align="center"><sub>✓&nbsp;100%&nbsp;free&nbsp;and&nbsp;open&nbsp;source &nbsp; ✓&nbsp;Nine&nbsp;GTM&nbsp;skills,&nbsp;one&nbsp;install &nbsp; ✓&nbsp;Built&nbsp;for&nbsp;the&nbsp;full&nbsp;GTM&nbsp;motion</sub></p>
 
-<p align="center">
-  ⭐ Used by top GTM teams
-</p>
+<p align="center"><small>⭐ Used by top GTM teams</small></p>
 
 <br />
 
@@ -34,16 +20,16 @@ The ICP that defines a market becomes the boundary for account segmentation and 
 
 ## Choose between repeated prompts, disconnected templates, custom agents — or one set of GTM skills built to work together
 
-|  | GTM Skills | Repeated prompts | Standalone templates | Custom agents |
-| --- | :---: | :---: | :---: | :---: |
-| Nine ready-made GTM skills | ✅ | ❌ | ❌ | ❌ |
-| Shared Git-backed GTM context | ✅ | ❌ | ❌ | ❌ |
-| ICP and persona lifecycle | ✅ | ❌ | ❌ | ❌ |
-| Account and lead segmentation | ✅ | ❌ | ❌ | ❌ |
-| Qualitative account and lead scoring | ✅ | ❌ | ❌ | ❌ |
-| Evidence-backed account and lead research | ✅ | ❌ | ❌ | ❌ |
-| Node-local organization support | ✅ | ❌ | ❌ | ❌ |
-| Paired benchmark evidence | ✅ | ❌ | ❌ | ❌ |
+| | **GTM Skills** | Repeated prompts | Standalone templates | Custom agents |
+|---|:---:|:---:|:---:|:---:|
+| **Nine ready-made GTM skills** | ✅ | ❌ | ❌ | ❌ |
+| **Shared Git-backed GTM context** | ✅ | ❌ | ❌ | ❌ |
+| **ICP and persona lifecycle** | ✅ | ❌ | ❌ | ❌ |
+| **Account and lead segmentation** | ✅ | ❌ | ❌ | ❌ |
+| **Qualitative account and lead scoring** | ✅ | ❌ | ❌ | ❌ |
+| **Evidence-backed account and lead research** | ✅ | ❌ | ❌ | ❌ |
+| **Node-local organization support** | ✅ | ❌ | ❌ | ❌ |
+| **Paired benchmark evidence** | ✅ | ❌ | ❌ | ❌ |
 
 Keep the durable market knowledge in one repository. Use the skill for the next job, let it read only the context it should see, and carry its qualified output into the following decision.
 
@@ -64,62 +50,27 @@ Inspect safe sources, keep findings separate from hypotheses, and return a brief
 ## Build your GTM context and run the first decision in three steps
 
 <table>
-  <tr>
-    <td width="33%" valign="top">
-      <strong>1. Install GTM Skills</strong>
-      <br /><br />
-      Run <code>npx skills add eliasstravik/gtmskills -g</code> to install the complete set of nine skills.
-    </td>
-    <td width="33%" valign="top">
-      <strong>2. Build your GTM context</strong>
-      <br /><br />
-      Run <code>/gtm-context</code> to create or import the organization repository, then add the ICPs and personas each organization owns.
-    </td>
-    <td width="33%" valign="top">
-      <strong>3. Use the skills</strong>
-      <br /><br />
-      Invoke segmentation, scoring, or research for the next account or lead decision.
-    </td>
-  </tr>
+<tr>
+<td align="center" valign="top" width="33%"><h3>1️⃣</h3><b>Install GTM Skills</b><br /><sub>Run <code>npx skills add eliasstravik/gtmskills -g</code> to install the complete set of nine skills.</sub></td>
+<td align="center" valign="top" width="33%"><h3>2️⃣</h3><b>Build your GTM context</b><br /><sub>Run <code>/gtm-context</code> to create or import the organization repository, then add the ICPs and personas each organization owns.</sub></td>
+<td align="center" valign="top" width="33%"><h3>3️⃣</h3><b>Use the skills</b><br /><sub>Invoke segmentation, scoring, or research for the next account or lead decision.</sub></td>
+</tr>
 </table>
 
-## Start self-serve or bring GTM Skills into your team with hands-on support
+## Choose how to get started
 
 <table>
-  <tr>
-    <td width="50%" valign="top">
-      <h3>Self-serve</h3>
-      <p>For GTM builders and teams using AI agents</p>
-      <h2>Free</h2>
-      <ul>
-        <li>Nine installable GTM skills</li>
-        <li>Git-backed organization context</li>
-        <li>ICP and persona authoring</li>
-        <li>Account and lead segmentation</li>
-        <li>Qualitative fit scoring</li>
-        <li>Evidence-backed account and lead research</li>
-      </ul>
-      <a href="https://github.com/eliasstravik/gtmskills/blob/main/docs/getting-started.md"><img src="assets/buttons/install-gtm-skills.svg" alt="Install GTM Skills" /></a>
-    </td>
-    <td width="50%" valign="top">
-      <h3>Done with you</h3>
-      <p>Hands-on setup and rollout for your GTM team</p>
-      <h2>Let’s talk</h2>
-      <ul>
-        <li>Everything in self-serve</li>
-        <li>Full GTM Skills setup</li>
-        <li>GTM context repository configuration</li>
-        <li>ICP and persona workflow design</li>
-        <li>Team rollout, training, and best practices</li>
-        <li>Ongoing maintenance and upgrades</li>
-        <li>Dedicated Slack channel support</li>
-      </ul>
-      <a href="https://cal.com/stravik/demo?projects=GTM%20Skills"><img src="assets/buttons/book-a-demo.svg" alt="Book a demo" /></a>
-    </td>
-  </tr>
+<tr>
+<td align="center" valign="top" width="50%"><h3>Self-serve</h3><sub>For GTM builders and teams using AI agents</sub><br /><h2>Free</h2><div align="left">&nbsp;&nbsp;&nbsp;✓&nbsp; Nine installable GTM skills<br />&nbsp;&nbsp;&nbsp;✓&nbsp; Git-backed organization context<br />&nbsp;&nbsp;&nbsp;✓&nbsp; ICP and persona authoring<br />&nbsp;&nbsp;&nbsp;✓&nbsp; Account and lead segmentation<br />&nbsp;&nbsp;&nbsp;✓&nbsp; Qualitative fit scoring<br />&nbsp;&nbsp;&nbsp;✓&nbsp; Evidence-backed account and lead research</div></td>
+<td align="center" valign="top" width="50%"><h3>Done-with-you</h3><sub>Hands-on setup and rollout for your GTM team</sub><br /><h2>Let's talk</h2><div align="left">&nbsp;&nbsp;&nbsp;✓&nbsp; Everything in self-serve<br />&nbsp;&nbsp;&nbsp;✓&nbsp; Full GTM Skills setup<br />&nbsp;&nbsp;&nbsp;✓&nbsp; GTM context repository configuration<br />&nbsp;&nbsp;&nbsp;✓&nbsp; ICP and persona workflow design<br />&nbsp;&nbsp;&nbsp;✓&nbsp; Team rollout, training, and best practices<br />&nbsp;&nbsp;&nbsp;✓&nbsp; Ongoing maintenance and upgrades<br />&nbsp;&nbsp;&nbsp;✓&nbsp; Dedicated Slack channel support</div></td>
+</tr>
+<tr>
+<td align="center"><a href="https://github.com/eliasstravik/gtmskills/blob/main/docs/getting-started.md"><img src="assets/buttons/install-gtm-skills.svg" alt="Install GTM Skills" /></a></td>
+<td align="center"><a href="https://cal.com/stravik/demo?projects=GTM%20Skills" target="_blank" rel="noopener noreferrer"><img src="assets/buttons/book-a-demo.svg" alt="Book a demo" /></a></td>
+</tr>
 </table>
 
-## Frequently asked questions
+## Get your questions answered
 
 ### Do I need to know how to code?
 
@@ -147,18 +98,10 @@ GTM Skills is free, open source, and MIT licensed. Your AI or model provider may
 
 ## Install GTM Skills and run your next decision from shared truth
 
-One repository holds what your team knows about the market. Nine focused skills turn that context into the next account or lead decision.
+<p align="center">One repository holds what your team knows about the market. Nine focused skills turn that context into the next account or lead decision.</p>
 
-<p align="center">
-  <a href="https://github.com/eliasstravik/gtmskills/blob/main/docs/getting-started.md"><img src="assets/buttons/install-gtm-skills.svg" alt="Install GTM Skills" /></a>
-  &nbsp;
-  <a href="https://cal.com/stravik/demo?projects=GTM%20Skills"><img src="assets/buttons/book-a-demo.svg" alt="Book a demo" /></a>
-</p>
+<p align="center"><a href="https://github.com/eliasstravik/gtmskills/blob/main/docs/getting-started.md"><img src="assets/buttons/install-gtm-skills.svg" alt="Install GTM Skills" /></a>&nbsp;&nbsp;<a href="https://cal.com/stravik/demo?projects=GTM%20Skills" target="_blank" rel="noopener noreferrer"><img src="assets/buttons/book-a-demo.svg" alt="Book a demo" /></a></p>
 
-<p align="center">
-  ✓ 100% free and open source &nbsp;&nbsp; ✓ Nine GTM skills, one install &nbsp;&nbsp; ✓ Built for the full GTM motion
-</p>
+<p align="center"><sub>✓&nbsp;100%&nbsp;free&nbsp;and&nbsp;open&nbsp;source &nbsp; ✓&nbsp;Nine&nbsp;GTM&nbsp;skills,&nbsp;one&nbsp;install &nbsp; ✓&nbsp;Built&nbsp;for&nbsp;the&nbsp;full&nbsp;GTM&nbsp;motion</sub></p>
 
-<p align="center">
-  ⭐ Used by top GTM teams
-</p>
+<p align="center"><small>⭐ Used by top GTM teams</small></p>

--- a/README.md
+++ b/README.md
@@ -158,3 +158,7 @@ One repository holds what your team knows about the market. Nine focused skills 
 <p align="center">
   ✓ 100% free and open source &nbsp;&nbsp; ✓ Nine GTM skills, one install &nbsp;&nbsp; ✓ Built for the full GTM motion
 </p>
+
+<p align="center">
+  ⭐ Used by top GTM teams
+</p>


### PR DESCRIPTION
## What changed

- add `⭐ Used by top GTM teams` beneath the closing CTA
- match the README markup used by Codebound, Rowbound, and Greenware
- use compact proof and social-proof typography with `<sub>` and `<small>`
- center the three-step cards and use the same numbered heading hierarchy
- rebuild the self-serve and done-with-you cards with compact subtitles, aligned check rows, and a separate CTA row
- align comparison-table emphasis, FAQ heading, CTA spacing, and closing-copy treatment with the other public repositories

## Why

The original GTM Skills README preserved the intended content but did not preserve the exact HTML structure that controls typography, alignment, and spacing across the other public repository landing pages. Native paragraphs and lists made the pricing section and supporting proof render differently.

## Impact

The README now follows the same visual system as the other public repositories while keeping the approved GTM Skills positioning and installation path.

## Validation

- compared live README markup from Codebound, Rowbound, and Greenware
- rendered the updated README through GitHub's Markdown API
- confirmed the closing social proof appears exactly once beneath each CTA group
- confirmed deprecated list/card markup is absent
- `git diff --check`