### PR TITLE
Ignore local Paperclip state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ evals/*/runs/
 # Local Superpowers planning artifacts do not belong in this repository.
 docs/superpowers/
 
+# Local Paperclip execution worktrees and runtime state.
+.paperclip/
+
 # Per-run description transcripts.
 evals/*/description/**/transcripts/
 


### PR DESCRIPTION
## What changed

- Added `.paperclip/` to `.gitignore`.
- Documented that the directory contains local Paperclip execution worktrees and runtime state.

## Why

Paperclip creates machine-local execution state under `.paperclip/`. Ignoring it prevents local worktrees and runtime files from appearing as untracked repository changes.

## Impact

No runtime or product behavior changes. Contributors using Paperclip will have a clean Git working tree.

## Validation

- Confirmed the PR diff contains only `.gitignore`.
- Ran `git diff --check` successfully.