### PR TITLE
Store raw provider payloads in enrichment cache

### DIFF
--- a/evals/gtm-workflow/scripts/test-templates.mjs
+++ b/evals/gtm-workflow/scripts/test-templates.mjs
@@ -9,8 +9,8 @@ import { test } from "node:test";
 const repo = resolve(import.meta.dirname, "../../..");
 const templates = join(repo, "skills/gtm-workflow/templates");
 
-test("v3 templates pass the local, approval, scheduled, webhook, and sandbox paths", async (context) => {
-  const directory = await mkdtemp(join(tmpdir(), "gtm-workflow-v3-"));
+test("v4 templates pass the local, approval, scheduled, webhook, and sandbox paths", async (context) => {
+  const directory = await mkdtemp(join(tmpdir(), "gtm-workflow-v4-"));
   let vendor;
   let server;
   context.after(async () => {
@@ -58,7 +58,12 @@ test("v3 templates pass the local, approval, scheduled, webhook, and sandbox pat
     vendorCalls += 1;
     const url = new URL(request.url, "http://127.0.0.1");
     response.setHeader("content-type", "application/json");
-    response.end(JSON.stringify({ company: url.searchParams.get("domain") }));
+    response.end(
+      JSON.stringify({
+        company: url.searchParams.get("domain"),
+        providerRecordId: `vendor-${vendorCalls}`,
+      }),
+    );
   });
   await new Promise((resolvePromise) => vendor.listen(0, "127.0.0.1", resolvePromise));
   const vendorPort = vendor.address().port;
@@ -87,7 +92,7 @@ test("v3 templates pass the local, approval, scheduled, webhook, and sandbox pat
   await command("npm", ["run", "db:generate"], { cwd: directory, env });
   await command("npm", ["run", "db:migrate"], { cwd: directory, env });
   const check = await command("npm", ["run", "gtm", "--", "check"], { cwd: directory, env });
-  assert.deepEqual(JSON.parse(lastJsonLine(check.stdout)), { ok: true, workflows: 4, libVersion: 3 });
+  assert.deepEqual(JSON.parse(lastJsonLine(check.stdout)), { ok: true, workflows: 4, libVersion: 4 });
   const scheduledNoInput = await gtmFailure(directory, env, ["run", "scheduled-proof"]);
   assert.equal(scheduledNoInput.error.code, "invalid_input");
   assert.match(scheduledNoInput.error.message, /write scheduledInput to a file/);
@@ -136,6 +141,27 @@ test("v3 templates pass the local, approval, scheduled, webhook, and sandbox pat
   assert.equal((await tableRows(directory, env, "accounts")).length, 20);
   assert.equal(vendorCalls, 20);
   assert.equal((await readFile(fakeCount, "utf8")).length, 20);
+  const cached = await sqlRows(
+    directory,
+    env,
+    "select value, raw from enrichment_cache where provider = 'mock-data' order by inputs_hash limit 1",
+  );
+  assert.deepEqual(Object.keys(JSON.parse(cached[0].value)), ["company"]);
+  assert.equal(typeof JSON.parse(cached[0].raw).providerRecordId, "string");
+  const expandedCacheHit = await providerProbe(directory, env, {
+    runKey: "expanded-schema",
+    schema: "expanded",
+  });
+  assert.equal(expandedCacheHit.status, "cache_hit");
+  assert.equal(expandedCacheHit.value.providerRecordId, "vendor-1");
+  assert.equal(vendorCalls, 20);
+  const legacyCacheHit = await providerProbe(directory, env, {
+    runKey: "legacy-fallback",
+    schema: "legacy",
+  });
+  assert.equal(legacyCacheHit.status, "cache_hit");
+  assert.deepEqual(legacyCacheHit.value, { company: "legacy.test" });
+  assert.equal(vendorCalls, 20);
   const writeQuery = await gtmFailure(directory, env, [
     "query",
     "--sql",
@@ -285,6 +311,49 @@ async function tableRows(directory, env, table) {
 
 async function sqlRows(directory, env, sql) {
   return gtm(directory, env, ["query", "--sql", sql, "--format", "json"]);
+}
+
+async function providerProbe(directory, env, options) {
+  const script = `
+    const [{ provider }, { getDb }, { enrichmentCache }, { z }] = await Promise.all([
+      import("./lib/provider.ts"),
+      import("./lib/db.ts"),
+      import("./lib/schema.ts"),
+      import("zod"),
+    ]);
+    if (${JSON.stringify(options.schema)} === "legacy") {
+      const now = Date.now();
+      await (await getDb()).insert(enrichmentCache).values({
+        provider: "mock-data",
+        endpoint: "organization-lookup-v1",
+        inputsHash: "634f69893e1dc602fd23f311f27a4ac8d42ccc21059b47876d5b51d85117d1a3",
+        inputs: JSON.stringify({ domain: "legacy.test" }),
+        raw: null,
+        value: JSON.stringify({ company: "legacy.test" }),
+        expiresAt: now + 86_400_000,
+        createdAt: now,
+      });
+    }
+    const schema = ${JSON.stringify(options.schema)} === "expanded"
+      ? z.object({ company: z.string(), providerRecordId: z.string() })
+      : z.object({ company: z.string() });
+    const domain = ${JSON.stringify(options.schema)} === "expanded" ? "account-0.test" : "legacy.test";
+    const result = await provider({
+      name: "mock-data",
+      endpoint: "organization-lookup-v1",
+      input: { domain },
+      schema,
+      ttlMs: 86_400_000,
+      call: async () => { throw new Error("cache miss"); },
+      meta: { runKey: ${JSON.stringify(options.runKey)}, slug: "provider-probe" },
+    });
+    process.stdout.write(JSON.stringify(result));
+  `;
+  const result = await command(process.execPath, ["--import", "tsx", "--input-type=module", "-e", script], {
+    cwd: directory,
+    env,
+  });
+  return JSON.parse(result.stdout);
 }
 
 async function httpJson(url, init = {}, expectedStatus = 200) {

--- a/evals/gtm-workflow/skill-issue-checklist.md
+++ b/evals/gtm-workflow/skill-issue-checklist.md
@@ -8,7 +8,7 @@
 - [x] Bulky file, lifecycle, conversation, UI, and deployment rules live in focused references.
 - [x] Every reference over 100 lines has a table of contents.
 - [x] The description states positive and negative triggers in third person and stays below 1,024 characters.
-- [x] The v3 deterministic harness covers typed tables, migrations, dry run, paid-call caching, checkpoint approval, duplicate protection, approval denial and timeout, scheduled starts, webhook registration, and sandbox refusals.
+- [x] The v4 deterministic harness covers typed tables, migrations, dry run, paid-call caching, checkpoint approval, duplicate protection, approval denial and timeout, scheduled starts, webhook registration, and sandbox refusals.
 - [x] Model-graded assertions cover the five golden paths, table drift, and sandbox constraints without requiring live services.
 - [ ] Rerun trigger and paired model evaluations after a model-credit budget is approved.
 - [ ] Complete the production and real-provider checks listed in `evidence/live-verification-follow-ups.md` under an explicit spend budget.

--- a/skills/gtm-workflow/SKILL.md
+++ b/skills/gtm-workflow/SKILL.md
@@ -45,7 +45,7 @@ Report a run still active after the bounded poll so `gtm runs get` can retrieve 
 ## QC
 
 - Secrets never appear in prompts, tracked files, conversation, or command output; values move from `.env` through the shell only.
-- Compare every `// gtm-lib v3` header with the template before an action. Offer a recopy when versions differ and never apply it silently.
+- Compare every `// gtm-lib v4` header with the template before an action. Offer a recopy when versions differ and never apply it silently.
 - Copy the versioned lib, routes, scripts, and config verbatim and edit workflow-owned tables, adapters, migrations, and workflow files instead.
 - Route every paid vendor call through `provider()` and every model call through `agent()`.
 - Use committed migrations. The project has no `db:push` command.

--- a/skills/gtm-workflow/references/contract.md
+++ b/skills/gtm-workflow/references/contract.md
@@ -48,9 +48,9 @@ Ignore `node_modules/`, `.env*` except `.env.example`, `.vercel/`, `.well-known/
 
 ## Versioned files
 
-Every `lib/*.ts`, all three route files, `scripts/gtm.ts`, `drizzle.config.ts`, and `nitro.config.ts` starts with `// gtm-lib v3`. `package.json` carries `gtm.libVersion: 3`. Compare these versions before every action. Name differing files and offer a template recopy in the proposal. Compare headers, not hashes, and never recopy silently.
+Every `lib/*.ts`, all three route files, `scripts/gtm.ts`, `drizzle.config.ts`, and `nitro.config.ts` starts with `// gtm-lib v4`. `package.json` carries `gtm.libVersion: 4`. Compare these versions before every action. Name differing files and offer a template recopy in the proposal. Compare headers, not hashes, and never recopy silently.
 
-A v2 project has no `lib/schema.ts` or `drizzle/`. Offer a v3 re-scaffold through update: copy the v3 files, add the pinned dependencies and baseline migration, migrate, then recreate each workflow through create from its header and purpose. Present the full diff before saving. Keep old ignored JSON results.
+A v2 project has no `lib/schema.ts` or `drizzle/`. Offer a v4 re-scaffold through update: copy the v4 files, add the pinned dependencies and baseline migrations, migrate, then recreate each workflow through create from its header and purpose. Present the full diff before saving. Keep old ignored JSON results.
 
 ## Workflow and table contract
 

--- a/skills/gtm-workflow/references/deploy.md
+++ b/skills/gtm-workflow/references/deploy.md
@@ -39,7 +39,7 @@ Before linking, scan workflows for `agent()` calls. If any exists and ignored `.
 vercel install tursocloud --environment production --format=json
 ```
 
-This Vercel Marketplace slug and flag set is current as of the v3 build. If the CLI requires marketplace terms or plan selection, stop for that user decision. The integration supplies `TURSO_DATABASE_URL` and `TURSO_AUTH_TOKEN`.
+This Vercel Marketplace slug and flag set is current as of the v4 build. If the CLI requires marketplace terms or plan selection, stop for that user decision. The integration supplies `TURSO_DATABASE_URL` and `TURSO_AUTH_TOKEN`.
 
 5. Record whether `.env.local` existed before install. Since step 1 refused a preexisting file, delete `.env.local` if install created it and say so. The production database pair belongs in `.env.turso`, not `.env`.
 6. Run `vercel env pull .env.turso --environment production`. Require both Turso variables. If the auth token is not pullable, ask the user to create a database token in the Turso dashboard and write the pair directly to ignored `.env.turso`.

--- a/skills/gtm-workflow/references/flows.md
+++ b/skills/gtm-workflow/references/flows.md
@@ -44,7 +44,7 @@ Bootstrap during the first create and keep the draft outside the repository unti
 ## Create
 
 1. Resolve workspace, owner, and kind. Read the owner's relevant ICP and persona files.
-2. Compare the headered template version before editing an existing project. Offer a v3 recopy when needed.
+2. Compare the headered template version before editing an existing project. Offer a v4 recopy when needed.
 3. Resolve where it runs. For on-demand work, recommend this computer. For scheduled or webhook work, recommend Vercel. Explain that local scheduled work runs only when invoked and model calls on Vercel use the user's budgeted Gateway key.
 4. Resolve the purpose, explicit input shape, stable row key, result columns, paid stages, adapter docs, caps, timing, approval stages, checkpoint, and external writes.
 5. When the workflow needs a provider, read [providers](providers.md), write its adapter against the user's own credential, and test it against fixtures. The skill ships no adapter catalog.
@@ -61,7 +61,7 @@ Cancellation before step 11 writes no tracked bytes and no migration.
 ## Update
 
 1. Resolve the workflow and inspect its header, table, adapter, migrations, schedule, approvals, and deployment state.
-2. Compare every headered file with v3. Include any accepted recopy in the proposal.
+2. Compare every headered file with v4. Include any accepted recopy in the proposal.
 3. Agree the business change. A run-location switch is an update to the same workflow.
 4. Change only the workflow, table, adapter, environment names, cron entry, or deployment metadata required by the request.
 5. New columns are nullable or defaulted. For a rename, plan a custom migration and hand-write `ALTER TABLE ... RENAME`. Keep schedule headers, `scheduledInput`, and cron entries aligned.

--- a/skills/gtm-workflow/references/providers.md
+++ b/skills/gtm-workflow/references/providers.md
@@ -37,7 +37,7 @@ const result = await provider({
 });
 ```
 
-The call returns a validated `value`, the cost attributed to this run, and `cache_hit`, `success`, or `empty`. A cache hit writes a ledger row with zero cost. A miss writes the cache and one ledger row. A throw writes one `error` row and rethrows.
+The call returns a validated `value`, the cost attributed to this run, and `cache_hit`, `success`, or `empty`. A cache miss stores the adapter payload in `enrichment_cache.raw` before schema parsing and keeps the parsed copy in `value`. Cache hits parse `raw` so added schema fields can use the original response. Rows written before v4 have no `raw`, so they fall back to `value`. A cache hit writes a ledger row with zero cost. A miss writes the cache and one ledger row. A throw writes one `error` row and rethrows.
 
 When the service reports actual cost, return `{ value, costUsd }` from the adapter call. Otherwise `provider()` records the accepted fixed cost. `agent()` records reported model cost when available and the accepted `maxUsd` projection otherwise. Outcome reports distinguish projected model cost.
 

--- a/skills/gtm-workflow/templates/drizzle.config.ts
+++ b/skills/gtm-workflow/templates/drizzle.config.ts
@@ -1,4 +1,4 @@
-// gtm-lib v3
+// gtm-lib v4
 import { defineConfig } from "drizzle-kit";
 import { getDatabaseConfig } from "./lib/db-url";
 

--- a/skills/gtm-workflow/templates/drizzle/0001_wise_mac_gargan.sql
+++ b/skills/gtm-workflow/templates/drizzle/0001_wise_mac_gargan.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `enrichment_cache` ADD `raw` text;

--- a/skills/gtm-workflow/templates/drizzle/meta/0001_snapshot.json
+++ b/skills/gtm-workflow/templates/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,327 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "dcadf9ef-0364-444f-8f72-fdb0368442e0",
+  "prevId": "33883fc2-2a62-4ab6-8d5a-18ac136ab977",
+  "tables": {
+    "enrichment_cache": {
+      "name": "enrichment_cache",
+      "columns": {
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inputs_hash": {
+          "name": "inputs_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inputs": {
+          "name": "inputs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "raw": {
+          "name": "raw",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "enrichment_cache_provider_endpoint_inputs_hash_pk": {
+          "columns": [
+            "provider",
+            "endpoint",
+            "inputs_hash"
+          ],
+          "name": "enrichment_cache_provider_endpoint_inputs_hash_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "enrichment_runs": {
+      "name": "enrichment_runs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "run_key": {
+          "name": "run_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workflow": {
+          "name": "workflow",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inputs_hash": {
+          "name": "inputs_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "enrichment_runs_run_key_idx": {
+          "name": "enrichment_runs_run_key_idx",
+          "columns": [
+            "run_key"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "workflow_runs": {
+      "name": "workflow_runs",
+      "columns": {
+        "run_key": {
+          "name": "run_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "workflow": {
+          "name": "workflow",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input": {
+          "name": "input",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input_hash": {
+          "name": "input_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed": {
+          "name": "completed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "failed": {
+          "name": "failed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "checkpoint": {
+          "name": "checkpoint",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "webhook_url": {
+          "name": "webhook_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "approval": {
+          "name": "approval",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "workflow_runs_run_id_unique": {
+          "name": "workflow_runs_run_id_unique",
+          "columns": [
+            "run_id"
+          ],
+          "isUnique": true
+        },
+        "workflow_runs_live_idx": {
+          "name": "workflow_runs_live_idx",
+          "columns": [
+            "path",
+            "input_hash"
+          ],
+          "isUnique": true,
+          "where": "finished_at IS NULL"
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/skills/gtm-workflow/templates/drizzle/meta/_journal.json
+++ b/skills/gtm-workflow/templates/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1787756200390,
       "tag": "0000_even_ronan",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "6",
+      "when": 1787777723887,
+      "tag": "0001_wise_mac_gargan",
+      "breakpoints": true
     }
   ]
 }

--- a/skills/gtm-workflow/templates/lib/agent.ts
+++ b/skills/gtm-workflow/templates/lib/agent.ts
@@ -1,4 +1,4 @@
-// gtm-lib v3
+// gtm-lib v4
 // Call agent() from inside a "use step" function; see the workflow contract for the step rules.
 import { spawn } from "node:child_process";
 import { constants } from "node:fs";

--- a/skills/gtm-workflow/templates/lib/approve.ts
+++ b/skills/gtm-workflow/templates/lib/approve.ts
@@ -1,4 +1,4 @@
-// gtm-lib v3
+// gtm-lib v4
 import { defineHook, sleep } from "workflow";
 import { z } from "zod";
 import { updateRun } from "./steps";

--- a/skills/gtm-workflow/templates/lib/db-url.ts
+++ b/skills/gtm-workflow/templates/lib/db-url.ts
@@ -1,4 +1,4 @@
-// gtm-lib v3
+// gtm-lib v4
 import { mkdirSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 

--- a/skills/gtm-workflow/templates/lib/db.ts
+++ b/skills/gtm-workflow/templates/lib/db.ts
@@ -1,4 +1,4 @@
-// gtm-lib v3
+// gtm-lib v4
 import { createClient, type Client } from "@libsql/client";
 import {
   and,

--- a/skills/gtm-workflow/templates/lib/provider.ts
+++ b/skills/gtm-workflow/templates/lib/provider.ts
@@ -1,4 +1,4 @@
-// gtm-lib v3
+// gtm-lib v4
 import { createHash, randomUUID } from "node:crypto";
 import { and, eq } from "drizzle-orm";
 import { z } from "zod";
@@ -47,7 +47,7 @@ export async function provider<T extends z.ZodTypeAny>(
   )[0];
 
   if (cache && cache.expiresAt > now) {
-    const value = input.schema.parse(JSON.parse(cache.value));
+    const value = input.schema.parse(JSON.parse(cache.raw ?? cache.value));
     await writeLedger(input, inputsHash, "cache_hit", 0, null);
     return { value, costUsd: 0, status: "cache_hit" };
   }
@@ -65,6 +65,7 @@ export async function provider<T extends z.ZodTypeAny>(
         endpoint: input.endpoint,
         inputsHash,
         inputs: canonical,
+        raw: JSON.stringify(reported.value),
         value: JSON.stringify(value),
         expiresAt: now + input.ttlMs,
         createdAt: now,
@@ -77,6 +78,7 @@ export async function provider<T extends z.ZodTypeAny>(
         ],
         set: {
           inputs: canonical,
+          raw: JSON.stringify(reported.value),
           value: JSON.stringify(value),
           expiresAt: now + input.ttlMs,
           createdAt: now,

--- a/skills/gtm-workflow/templates/lib/schema.ts
+++ b/skills/gtm-workflow/templates/lib/schema.ts
@@ -1,4 +1,4 @@
-// gtm-lib v3
+// gtm-lib v4
 import { sql } from "drizzle-orm";
 import {
   index,
@@ -25,6 +25,7 @@ export const enrichmentCache = sqliteTable(
     endpoint: text("endpoint").notNull(),
     inputsHash: text("inputs_hash").notNull(),
     inputs: text("inputs").notNull(),
+    raw: text("raw"),
     value: text("value").notNull(),
     expiresAt: integer("expires_at").notNull(),
     createdAt: integer("created_at").notNull(),

--- a/skills/gtm-workflow/templates/lib/steps.ts
+++ b/skills/gtm-workflow/templates/lib/steps.ts
@@ -1,4 +1,4 @@
-// gtm-lib v3
+// gtm-lib v4
 import { updateRunPlain } from "./db";
 
 export type ApprovalState = {

--- a/skills/gtm-workflow/templates/nitro.config.ts
+++ b/skills/gtm-workflow/templates/nitro.config.ts
@@ -1,4 +1,4 @@
-// gtm-lib v3
+// gtm-lib v4
 import { defineConfig } from "nitro";
 
 export default defineConfig({

--- a/skills/gtm-workflow/templates/package.json
+++ b/skills/gtm-workflow/templates/package.json
@@ -32,6 +32,6 @@
     "typescript": "7.0.2"
   },
   "gtm": {
-    "libVersion": 3
+    "libVersion": 4
   }
 }

--- a/skills/gtm-workflow/templates/scripts/gtm.ts
+++ b/skills/gtm-workflow/templates/scripts/gtm.ts
@@ -1,4 +1,4 @@
-// gtm-lib v3
+// gtm-lib v4
 import { spawn } from "node:child_process";
 import { existsSync } from "node:fs";
 import { readFile, readdir } from "node:fs/promises";

--- a/skills/gtm-workflow/templates/server/api/approve/[token].post.ts
+++ b/skills/gtm-workflow/templates/server/api/approve/[token].post.ts
@@ -1,4 +1,4 @@
-// gtm-lib v3
+// gtm-lib v4
 import { defineEventHandler } from "nitro/h3";
 import { resumeHook } from "workflow/api";
 import { HookNotFoundError } from "workflow/internal/errors";

--- a/skills/gtm-workflow/templates/server/api/run/[...workflow].ts
+++ b/skills/gtm-workflow/templates/server/api/run/[...workflow].ts
@@ -1,4 +1,4 @@
-// gtm-lib v3
+// gtm-lib v4
 import { createHash, randomBytes } from "node:crypto";
 import { defineEventHandler } from "nitro/h3";
 import { start } from "workflow/api";

--- a/skills/gtm-workflow/templates/server/api/runs/[runId].get.ts
+++ b/skills/gtm-workflow/templates/server/api/runs/[runId].get.ts
@@ -1,4 +1,4 @@
-// gtm-lib v3
+// gtm-lib v4
 import { defineEventHandler } from "nitro/h3";
 import { getRun } from "workflow/api";
 import { WorkflowRunFailedError } from "workflow/errors";


### PR DESCRIPTION
## Summary

- store each unparsed provider response beside the validated cache value
- parse cache hits from the raw payload, with a fallback for pre-v4 rows
- add the nullable Drizzle migration and bump the managed runtime to gtm-lib v4
- extend the deterministic provider cache coverage for schema drift and legacy rows

## Verification

- `node --test evals/gtm-workflow/scripts/test-templates.mjs`
- `python3 scripts/check_repo_layout.py`
- `git diff --check`
- `npm run db:generate`
- `npm run db:migrate`

Fixes #40