### PR TITLE
Release gtm-workflow runtime v10

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,6 +1,6 @@
 # Getting started: build your GTM foundation
 
-GTM Skills gives your AI agent four focused Lifecycle SOPs that share one Git-backed source of truth. This guide takes you from installation to a GTM workspace with its first ICP, persona, and reusable workflow, without requiring you to write code.
+GTM Skills gives your AI agent four focused Lifecycle SOPs that share one Git-backed source of truth. This guide takes you from installation to a GTM workspace with its first ICP, persona, and reusable workflow: the agent writes the code, and you review one diff and one dry run.
 
 ## 1. Check the prerequisites
 

--- a/docs/gtm-agent-requirements.md
+++ b/docs/gtm-agent-requirements.md
@@ -1,16 +1,16 @@
-# GTM agent requirements for workflow v6
+# GTM agent requirements for workflow v10
 
-This is the host contract for a small Eve Slack agent that authors the v6 `gtm-workflow` project in one connected GTM workspace and runs it on Vercel. Vercel deploys the workflow project from that same repository. The sandbox never starts a real run.
+This is the host contract for a small Eve Slack agent that authors the v10 `gtm-workflow` project in one connected GTM workspace and runs it on Vercel. Vercel deploys the workflow project from that same repository. The sandbox never starts a real run.
 
 ## What belongs in the reusable gtm-agent template
 
 The template owns the mechanism:
 
 - Slack is the only channel.
-- `apply_gtm_workspace_changes` is the only authored write tool. Its request names every migration file it carries and declares whether any statement is destructive; the host refuses an undeclared `DROP`. It applies accepted workflow migrations through a write credential that exists only for that step and saves one approved atomic commit to `main`. If the commit fails after migrations applied, the result says so.
+- `apply_gtm_workspace_changes` is the only authored write tool. Its request names every migration, includes full SQL for non-additive statements, and declares `DELETE`, `UPDATE`, `RENAME`, `DROP`, and `CREATE TRIGGER` destructive. It applies accepted migrations through a write credential that exists only for that step and saves one approved atomic commit to `main`. If the commit fails after migrations applied, the result says so.
 - `operate_gtm_workflow` has read-only preview and status actions plus approval-gated start, approval, and cancel actions. Start carries the rows and projected cost the approver saw and refuses when the fresh dry run disagrees.
-- One host module dry-runs the exact workspace HEAD, waits until the protected production runtime reports that same Git SHA, starts it with an atomic SHA recheck, and strips input, hook tokens, webhook URLs, and credentials from results.
-- The sandbox remains deny-all except npm, the workspace Turso host with a read-only credential, and accepted provider hosts without credentials. It never receives the production run bearer, OIDC token, hook tokens, a Gateway key, or a database write credential. It authors, validates, dry-runs, and queries; it starts no real run.
+- One host module dry-runs the exact workspace HEAD, waits until the protected production runtime reports that same Git SHA, starts it with a required atomic SHA recheck, and strips input, public webhook URLs, and credentials from results.
+- The sandbox remains deny-all except npm, the workspace Turso host with a read-only credential, and accepted provider hosts without credentials. It never receives the production run bearer, OIDC token, a Gateway key, or a database write credential. It authors, validates, dry-runs, and queries; it starts no real run.
 
 For `Runs: on Vercel`, save and deploy are one state transition: the accepted `main` commit starts Vercel's Git deployment. A real run remains a separate approval.
 
@@ -72,7 +72,7 @@ The save proposal must state that accepting a Vercel-workflow batch commits it t
 Inside the one approval-gated write operation, the host:
 
 1. verifies the connected checkout and remote `main` still match the requested full commit ID;
-2. verifies the declared migration list matches the SQL additions and that any `DROP` is declared destructive;
+2. verifies the declared migration list matches the SQL additions, requires full SQL for non-additive changes, and checks every destructive keyword declaration;
 3. stages the accepted tracked `workflows/` tree outside the checkout;
 4. opens the write credential, applies new committed migrations to the workspace Turso database, and restores the read-only baseline;
 5. creates the one atomic GitHub commit with the configured Vercel-recognized author and the GitHub App as committer; and
@@ -84,7 +84,7 @@ Vercel's Git integration deploys the commit. `api.vercel.com` stays closed to bo
 
 ## Run control
 
-Preview runs the committed workflow's zero-spend dry run against one ignored `workflows/data/*.json` input and reports rows, stages, projected cost, caps, and checkpoint.
+Preview imports the committed workflow, validates its exported Zod input, performs the zero-spend dry run against one ignored input file, and reports parsed rows, stages, projected cost, caps, and checkpoint.
 
 Start repeats the dry run, refuses when its rows or projected cost differ from the values the approver accepted, then polls the protected `GET /api/deployment` route until it returns the requested workspace SHA. It reads the bounded ignored input and calls the production route with:
 
@@ -92,9 +92,9 @@ Start repeats the dry run, refuses when its rows or projected cost differ from t
 - a short-lived `x-vercel-trusted-oidc-idp-token` from the Eve production deployment; and
 - `x-gtm-workspace-head` carrying the same SHA.
 
-The production POST route rejects a mismatch with `409 deployment_not_ready`, closing the race between readiness polling and start. A timeout starts nothing.
+The production POST route rejects a missing header with `409 deployment_head_required` and a mismatch with `409 deployment_not_ready`, closing the race between readiness polling and start. A timeout starts nothing.
 
-Status returns the public run key and sanitized business state. Approval fetches the pending run, resolves its hook token internally, submits the accepted decision, and never returns the token. Cancel posts to the bearer-protected cancel route, reports the run as `cancelled`, and treats `409 run_not_active` as already finished.
+Status returns the public run key and sanitized business state, including `completed`, `stopped`, `timed_out`, `cancelling`, `failed`, or `cancelled`, plus stop reason, remaining keys, failed step, and cost sources. Approval fetches the pending run and submits one typed decision; the token only names that pending stage. Cancel posts to the bearer-protected route, polls through `cancelling` to `cancelled`, and treats `409 run_not_active` as already finished.
 
 ## Draft and checkout paths
 

--- a/evals/gtm-workflow/assertions.md
+++ b/evals/gtm-workflow/assertions.md
@@ -7,7 +7,7 @@ The deterministic grader maps each sentence in `evals.json` to repository state,
 - Every question-bearing assistant turn starts with one bold question.
 - Every discrete choice uses numbered options, at most one `(Recommended)`, and the exact reply line.
 - No transcript contains `AskUserQuestion`, a value from ignored environment files, or credentials.
-- Headered v7 library files and API routes match the shipped templates after create or update work.
+- Headered v10 managed files match their recorded SHA-256 hashes after create or accepted update work; local modifications are diffed before recopy.
 - Runtime state, environment files, Turso pull files, and `data/` remain ignored.
 - Database generation and migration happen only after the user accepts the table proposal.
 - Inspection cases are read-only. Sandbox cases do not expose ports or use remote Git commands.
@@ -18,20 +18,21 @@ The deterministic grader maps each sentence in `evals.json` to repository state,
 - Scheduled workflows also declare a schedule and `scheduledInput`.
 - Kebab-case files export camelCase functions.
 - Typed business tables live in `db/tables/`; fixed runtime tables live in `lib/schema.ts`.
-- `MAX_ROWS` and projected `MAX_SPEND_USD` are enforced before provider or agent spend.
+- `runRows()` enforces `MAX_ROWS` and projected `MAX_SPEND_USD` before spend, then checks ledger actuals after every row.
 - Every paid step sets `maxRetries = 0`; every paid call passes through `provider()` or `agent()` with run metadata.
-- Each row catches errors, records failures, and continues.
-- Dry runs make no route, provider, model, ledger, or database mutation.
+- Each row isolates ordinary errors; authentication and quota errors stop with a reason and remaining keys.
+- Dry runs validate the exported input schema, count parsed rows, and make no route, provider, model, ledger, or database mutation.
 
 ## Runtime controls
 
-- Start routes insert the durable run row before calling `start()` and reject a matching live run with 409.
+- Start routes insert the durable row before `start()`, pass searchable attributes, require the production commit header, and reject a matching live run with 409; the workflow self-registers its SDK run id.
 - GET starts a scheduled workflow with `[null, meta]`; POST starts with `[body, meta]`.
-- `--wait` returns at `waiting` so the operator can review the approval or webhook summary.
+- `--wait` returns at `waiting` so the operator can review approval or trigger state.
 - Approvals resume through the generated token route. Zombie recovery cancels by run ID and then reconciles by run key.
-- The bearer-protected cancel route stops a live run, records `cancelled`, answers 409 for a finished run, and leaves its approval token unusable.
-- Cache hits create zero-cost ledger rows for the current run. An agent call with no reported cost records its `maxUsd` projection.
-- Webhook URLs are learned from `runs get`, not the initial start response.
+- The cancel route records `cancelling` without finishing the row, keeps duplicate protection closed, then reconciles terminal `cancelled`; stale approvals return 409.
+- Denial records `stopped`, approval expiry records `timed_out`, and status output includes stop reason, remaining keys, failed step, run URL, and cost sources.
+- Paid cache misses write `pending` before the call; terminal reconciliation converts stale pending rows to `lost`. Cache hits cost zero, pre-call failures cost zero, and cost sources distinguish reported, fixed, and projected.
+- Triggered workflows prefer the bearer-protected typed trigger route; public per-run webhooks remain capabilities and require payload validation.
 
 ## Cloud and sandbox controls
 
@@ -40,7 +41,9 @@ The deterministic grader maps each sentence in `evals.json` to repository state,
 - Secret values move only through environment-aware commands and never enter evidence.
 - Sandbox mode rejects file databases and CLI model backends. A hosted sandbox starts no real run, holds a read-only database credential, and applies migrations only inside the approval-gated save.
 - No live cloud, provider, model, or credential-brokering operation is part of the deterministic suite.
-- Hosted controls keep production run bearers, OIDC tokens, hook tokens, and webhook URLs outside both the sandbox and the visible transcript. No Vercel deploy token exists.
-- The save gate names its production deployment effect. Its approved operation applies backward-compatible migrations before the atomic `main` commit. Preview and status are read-only; real start, approval, and cancel remain separately approval-gated. The save names each migration file and declares destructive statements.
-- A trusted start waits for `GET /api/deployment` to report the accepted commit and sends the same SHA to the POST run route.
+- Hosted controls keep production run bearers, OIDC tokens, and public webhook URLs outside both the sandbox and the visible transcript. Hook tokens only name pending stages. No Vercel deploy token exists.
+- The save gate names its production deployment effect. Its approved operation applies backward-compatible migrations before the atomic `main` commit. Preview and status are read-only; real start, approval, and cancel remain separately approval-gated. The save names each migration and shows full SQL for non-additive statements.
+- A trusted start waits for `GET /api/deployment` to report the accepted commit and sends the same SHA; a missing or mismatched header is rejected.
+- Cloud query and Studio require the read-only token and never reuse the migration token.
+- The shipped command hook allows inspection and dry runs but asks for spend, decisions, cancellation, migrations, deployment, or unsafe shell syntax.
 - A hosted Git deployment requires a verified commit author mapped to the Vercel owner or team; the GitHub App remains the committer.

--- a/evals/gtm-workflow/evals.json
+++ b/evals/gtm-workflow/evals.json
@@ -63,16 +63,16 @@
     },
     {
       "id": 5,
-      "name": "webhook-lifecycle",
+      "name": "trigger-lifecycle",
       "fixture": "local-project",
-      "prompt": "Design a triggered Acme workflow that waits on a per-run webhook and writes the webhook URL into workflow_runs. Validate the source locally, but do not deploy it or call any public webhook.",
-      "expected_output": "A triggered workflow using createWebhook(), durable waiting and running transitions, and a deferred production verification note.",
+      "prompt": "Design a triggered Acme workflow that waits on a typed hook resumed through the bearer-protected trigger route. Validate the source locally, but do not deploy it or call a production route.",
+      "expected_output": "A triggered workflow using waitForTrigger(), durable waiting and running transitions, and a deferred production verification note.",
       "files": ["evals/gtm-workflow/fixtures/local-project"],
       "assertions": [
-        "The workflow creates a webhook in workflow context, stores webhook_url while waiting, awaits it, then records running and terminal state.",
-        "The run route does not claim to return the URL before the workflow creates it.",
-        "The local procedure obtains the URL through gtm runs get and authenticates the webhook payload itself.",
-        "Deployment and public webhook delivery are listed as later checks and are not executed."
+        "The workflow waits on the exported typed trigger hook, stores trigger_token while waiting, then records running and terminal state.",
+        "The trigger token only names the pending stage; the bearer-protected trigger route authorizes and validates resume.",
+        "The local procedure obtains waiting state through gtm runs get and posts a validated fixture to the authorized route.",
+        "Deployment and production trigger delivery are listed as later checks and are not executed."
       ]
     },
     {

--- a/evals/gtm-workflow/evidence/live-verification-follow-ups.md
+++ b/evals/gtm-workflow/evidence/live-verification-follow-ups.md
@@ -6,10 +6,9 @@ These checks are intentionally deferred. The issue implementation and determinis
 2. Apply `db:migrate:cloud`, deploy the fixture, and confirm a checkpointed production run can be inspected and approved.
 3. Query the production rows with `gtm query --cloud` and inspect them with `db:studio:cloud`.
 4. Invoke a deployed scheduled route once with `CRON_SECRET` and verify duplicate protection.
-5. Resume a deployed `createWebhook()` URL once and verify the run reaches `completed`.
+5. Resume a deployed typed trigger through the bearer-protected route once and verify the run reaches `completed`; separately verify a public webhook only for a caller that cannot send the bearer.
 6. Repeat the cache and zero-cost rerun checks with a real provider and model under an explicit budget.
 7. Verify sandbox HTTP transport, credential brokering, deployment authority, and trusted-host approval delivery in the gtm-agent environment.
 8. Run the model-graded eval suite after approving its model-credit budget.
-9. Recheck webhook resume when the Workflow SDK supports Node 24; the pinned SDK currently passes the end-to-end loopback check on Node 22.
 
 Before committing any live evidence, scan it for bearer values, Turso tokens, model keys, provider keys, and `.env.turso` contents.

--- a/evals/gtm-workflow/scripts/test-templates.mjs
+++ b/evals/gtm-workflow/scripts/test-templates.mjs
@@ -9,8 +9,8 @@ import { test } from "node:test";
 const repo = resolve(import.meta.dirname, "../../..");
 const templates = join(repo, "skills/gtm-workflow/templates");
 
-test("v9 templates pass the local, approval, scheduled, webhook, cancel, and sandbox paths", async (context) => {
-  const directory = await mkdtemp(join(tmpdir(), "gtm-workflow-v9-"));
+test("v10 templates pass the deterministic workflow contract", async (context) => {
+  const directory = await mkdtemp(join(tmpdir(), "gtm-workflow-v10-"));
   let vendor;
   let server;
   context.after(async () => {
@@ -40,7 +40,11 @@ test("v9 templates pass the local, approval, scheduled, webhook, cancel, and san
   await writeFile(join(directory, "workflows/local-proof.ts"), localWorkflow);
   await writeFile(join(directory, "workflows/approval-proof.ts"), approvalWorkflow);
   await writeFile(join(directory, "workflows/scheduled-proof.ts"), scheduledWorkflow);
-  await writeFile(join(directory, "workflows/webhook-proof.ts"), webhookWorkflow);
+  await writeFile(join(directory, "workflows/trigger-proof.ts"), triggerWorkflow);
+  await writeFile(join(directory, "workflows/slow-proof.ts"), slowWorkflow);
+  await writeFile(join(directory, "workflows/error-proof.ts"), errorWorkflow);
+  await writeFile(join(directory, "workflows/spend-proof.ts"), spendWorkflow);
+  await writeFile(join(directory, "workflows/held-proof.ts"), heldWorkflow);
   await writeFile(join(directory, "vercel.json"), JSON.stringify({ crons: [{ path: "/api/run/scheduled-proof", schedule: "0 9 * * *" }] }));
 
   const fakeDirectory = join(directory, "fake-bin");
@@ -58,12 +62,14 @@ test("v9 templates pass the local, approval, scheduled, webhook, cancel, and san
     vendorCalls += 1;
     const url = new URL(request.url, "http://127.0.0.1");
     response.setHeader("content-type", "application/json");
-    response.end(
+    const send = () => response.end(
       JSON.stringify({
         company: url.searchParams.get("domain"),
         providerRecordId: `vendor-${vendorCalls}`,
       }),
     );
+    if (url.searchParams.get("domain") === "slow.test") setTimeout(send, 5_000);
+    else send();
   });
   await new Promise((resolvePromise) => vendor.listen(0, "127.0.0.1", resolvePromise));
   const vendorPort = vendor.address().port;
@@ -76,6 +82,7 @@ test("v9 templates pass the local, approval, scheduled, webhook, cancel, and san
     GTM_AGENT_BACKEND: "claude",
     GTM_RUN_SECRET: secret,
     VERCEL_GIT_COMMIT_SHA: deploymentHead,
+    FIXTURE_API_TOKEN: "credential-to-redact",
     MOCK_VENDOR_URL: `http://127.0.0.1:${vendorPort}`,
     GTM_BASE_URL: `http://127.0.0.1:${nitroPort}`,
     WORKFLOW_LOCAL_BASE_URL: `http://127.0.0.1:${nitroPort}`,
@@ -94,7 +101,18 @@ test("v9 templates pass the local, approval, scheduled, webhook, cancel, and san
   await command("npm", ["run", "db:generate"], { cwd: directory, env });
   await command("npm", ["run", "db:migrate"], { cwd: directory, env });
   const check = await command("npm", ["run", "gtm", "--", "check"], { cwd: directory, env });
-  assert.deepEqual(JSON.parse(lastJsonLine(check.stdout)), { ok: true, workflows: 4, libVersion: 9 });
+  const checked = JSON.parse(lastJsonLine(check.stdout));
+  assert.equal(checked.ok, true);
+  assert.equal(checked.workflows, 8);
+  assert.equal(checked.libVersion, 10);
+  await command("npm", ["run", "db:verify"], { cwd: directory, env });
+  const migrationPath = join(directory, "drizzle/0002_abandoned_quentin_quire.sql");
+  const migrationSource = await readFile(migrationPath, "utf8");
+  await writeFile(migrationPath, `${migrationSource}\n-- changed after apply\n`);
+  const editedLedger = await commandFailure("npm", ["run", "db:verify"], { cwd: directory, env });
+  assert.match(editedLedger.stderr, /Migration ledger is missing/);
+  await writeFile(migrationPath, migrationSource);
+  await assertCheckRules(directory, env);
   await writeFile(
     join(directory, ".env.turso"),
     "TURSO_DATABASE_URL=libsql://fixture.turso.io\nTURSO_AUTH_TOKEN=\n",
@@ -104,6 +122,10 @@ test("v9 templates pass the local, approval, scheduled, webhook, cancel, and san
     env,
   });
   assert.match(missingCloudToken.stderr, /TURSO_AUTH_TOKEN must be non-empty/);
+  const writeOnlyCloudQuery = await gtmFailure(directory, env, ["query", "--cloud", "--sql", "SELECT 1"]);
+  assert.equal(writeOnlyCloudQuery.error.code, "missing_read_only_token");
+  const writeOnlyCloudStudio = await commandFailure("npm", ["run", "db:studio:cloud"], { cwd: directory, env });
+  assert.match(writeOnlyCloudStudio.stderr, /TURSO_READ_ONLY_AUTH_TOKEN is required/);
   await rm(join(directory, ".env.turso"));
   await command("npm", ["run", "build"], { cwd: directory, env });
   await writeFile(join(directory, "drizzle/9999_orphan.sql"), "SELECT 1;\n");
@@ -111,15 +133,39 @@ test("v9 templates pass the local, approval, scheduled, webhook, cancel, and san
   assert.equal(orphanMigration.error.code, "invalid_migration_artifacts");
   await rm(join(directory, "drizzle/9999_orphan.sql"));
 
+  const cloudQuery = await gtmFailure(directory, env, ["query", "--cloud", "--sql", "SELECT 1"]);
+  assert.equal(cloudQuery.error.code, "missing_cloud_env");
+
   const localWorkflowPath = join(directory, "workflows/local-proof.ts");
   const validLocalWorkflow = await readFile(localWorkflowPath, "utf8");
   await writeFile(localWorkflowPath, validLocalWorkflow.replace("  arg = input.parse(arg);\n", ""));
   const missingInputParse = await gtmFailure(directory, env, ["check"]);
   assert.equal(missingInputParse.error.code, "invalid_input_parse");
   await writeFile(localWorkflowPath, validLocalWorkflow);
+  const malformedInput = join(directory, "data/malformed.json");
+  await mkdir(dirname(malformedInput), { recursive: true });
+  await writeFile(malformedInput, JSON.stringify({ rows: [{ key: "missing-domain" }] }));
+  const malformedDryRun = await gtmFailure(directory, env, ["run", "local-proof", "--input", malformedInput, "--dry-run"]);
+  assert.equal(malformedDryRun.error.code, "invalid_input_schema");
+  const unrelatedArrayInput = join(directory, "data/unrelated-array.json");
+  await writeFile(unrelatedArrayInput, JSON.stringify({ rows: [{ key: "one", domain: "one.test" }], unrelated: [1, 2, 3, 4] }));
+  const unrelatedDryRun = await gtm(directory, env, ["run", "local-proof", "--input", unrelatedArrayInput, "--dry-run"]);
+  assert.equal(unrelatedDryRun.rows, 1);
   const scheduledNoInput = await gtmFailure(directory, env, ["run", "scheduled-proof"]);
   assert.equal(scheduledNoInput.error.code, "invalid_input");
   assert.match(scheduledNoInput.error.message, /write scheduledInput to a file/);
+
+  // Exercise workflow self-registration without relying on the route's best-effort write.
+  const runRoute = join(directory, "server/api/run/[...workflow].ts");
+  const runRouteSource = await readFile(runRoute, "utf8");
+  await writeFile(
+    runRoute,
+    runRouteSource.replace(
+      "await updateRunPlain(runKey, { runId: run.runId }).catch(() => undefined);",
+      "await Promise.resolve();",
+    ),
+  );
+  await command("npm", ["run", "build"], { cwd: directory, env });
 
   server = spawn(join(directory, "node_modules/.bin/nitro"), ["dev", "--port", String(nitroPort)], {
     cwd: directory,
@@ -139,6 +185,13 @@ test("v9 templates pass the local, approval, scheduled, webhook, cancel, and san
   });
   assert.equal(deployment.status, 200);
   assert.deepEqual(await deployment.json(), { head: deploymentHead });
+  const missingHeadStart = await fetch(`${env.GTM_BASE_URL}/api/run/local-proof`, {
+    method: "POST",
+    headers: { authorization: `Bearer ${secret}`, "content-type": "application/json" },
+    body: "{}",
+  });
+  assert.equal(missingHeadStart.status, 409);
+  assert.equal((await missingHeadStart.json()).error.code, "deployment_head_required");
   const mismatchedStart = await fetch(`${env.GTM_BASE_URL}/api/run/local-proof`, {
     method: "POST",
     headers: {
@@ -173,6 +226,8 @@ test("v9 templates pass the local, approval, scheduled, webhook, cancel, and san
   ]);
   assert.equal(paused.status, "waiting");
   assert.equal(paused.completed, 3);
+  assert.equal(typeof paused.runId, "string");
+  assert.equal(typeof paused.runUrl, "string");
   assert.equal((await tableRows(directory, env, "accounts")).length, 3);
   const duplicate = await gtmFailure(directory, env, ["run", "local-proof", "--input", inputFile]);
   assert.equal(duplicate.error.code, "run_in_progress");
@@ -212,6 +267,12 @@ test("v9 templates pass the local, approval, scheduled, webhook, cancel, and san
   ]);
   assert.equal(writeQuery.error.code, "internal_error");
   assert.equal((await tableRows(directory, env, "accounts")).length, 20);
+  const cteQuery = await gtm(directory, env, [
+    "query",
+    "--sql",
+    "WITH selected AS (SELECT key FROM accounts LIMIT 1) SELECT * FROM selected",
+  ]);
+  assert.equal(cteQuery.length, 1);
 
   const rerun = await gtm(directory, env, ["run", "local-proof", "--input", inputFile, "--wait"]);
   assert.equal(rerun.status, "completed");
@@ -230,14 +291,52 @@ test("v9 templates pass the local, approval, scheduled, webhook, cancel, and san
     `select cost_usd from workflow_runs where run_key = '${rerun.runKey}'`,
   );
   assert.equal(rerunCost[0].cost_usd, 0);
+  const firstCostSources = await sqlRows(
+    directory,
+    env,
+    `select provider, cost_source from enrichment_runs where run_key = '${completed.runKey}' group by provider, cost_source order by provider`,
+  );
+  assert.deepEqual(firstCostSources, [
+    { provider: "agent", cost_source: "reported" },
+    { provider: "mock-data", cost_source: "fixed" },
+  ]);
+
+  const beforeCapCalls = vendorCalls;
+  const capResponse = await httpJson(`${env.GTM_BASE_URL}/api/run/local-proof`, {
+    method: "POST",
+    headers: { authorization: `Bearer ${secret}`, "x-gtm-workspace-head": deploymentHead },
+    body: JSON.stringify({ rows: Array.from({ length: 26 }, (_, index) => ({ key: `cap-${index}`, domain: `cap-${index}.test` })) }),
+  });
+  const capDone = await waitForRun(directory, env, capResponse.runKey, "failed");
+  assert.equal(capDone.stopReason, "caps_exceeded");
+  assert.equal(vendorCalls, beforeCapCalls);
+
+  const spendInput = join(directory, "data/spend.json");
+  await writeFile(spendInput, JSON.stringify({ rows: ["one", "two", "three"].map((key) => ({ key, domain: `spend-${key}.test` })) }));
+  const spendDone = await gtm(directory, env, ["run", "spend-proof", "--input", spendInput, "--wait"]);
+  assert.equal(spendDone.status, "stopped");
+  assert.equal(spendDone.stopReason, "spend_cap");
+  assert.equal(spendDone.completed, 2);
+  assert.deepEqual(spendDone.remaining_keys, ["three"]);
+
+  const heldInput = join(directory, "data/held.json");
+  await writeFile(heldInput, JSON.stringify({ rows: Array.from({ length: 5 }, (_, index) => ({ key: `held-${index}` })) }));
+  const heldDone = await gtm(directory, env, ["run", "held-proof", "--input", heldInput, "--wait"]);
+  assert.equal(heldDone.status, "stopped");
+  assert.equal(heldDone.stopReason, "provider_auth");
+  assert.deepEqual(heldDone.remaining_keys, ["held-2", "held-3", "held-4"]);
+  assert.equal((await sqlRows(directory, env, `select * from enrichment_runs where run_key = '${heldDone.runKey}'`)).length, 2);
 
   const denied = await startAndWait(directory, env, "approval-proof", { case: "deny" });
   const hooks = await command("npx", ["workflow", "inspect", "hooks", "--runId", denied.runId], { cwd: directory, env });
   assert.match(hooks.stdout, /hookId/);
   const deniedDone = await gtm(directory, env, ["approve", denied.approval.token, "--no", "--wait"]);
-  assert.equal(deniedDone.status, "completed");
+  assert.equal(deniedDone.status, "stopped");
+  assert.equal(deniedDone.stopReason, "operator_denied");
   assert.equal(deniedDone.approval.approved, false);
   assert.equal((await tableRows(directory, env, "approval_effects")).length, 0);
+  const deniedAgain = await gtmFailure(directory, env, ["approve", denied.approval.token, "--yes"]);
+  assert.equal(deniedAgain.error.code, "approval_not_pending");
 
   const accepted = await startAndWait(directory, env, "approval-proof", { case: "approve" });
   const acceptedDone = await gtm(directory, env, ["approve", accepted.approval.token, "--yes", "--wait"]);
@@ -247,21 +346,25 @@ test("v9 templates pass the local, approval, scheduled, webhook, cancel, and san
   assert.equal(toCancel.status, "waiting");
   const unauthenticatedCancel = await fetch(`${env.GTM_BASE_URL}/api/runs/${toCancel.runKey}/cancel`, { method: "POST" });
   assert.equal(unauthenticatedCancel.status, 401);
-  const cancelled = await gtm(directory, env, ["cancel", toCancel.runKey, "--reason", "operator stopped it"]);
+  const cancelling = await gtm(directory, env, ["cancel", toCancel.runKey, "--reason", "operator stopped it"]);
+  assert.equal(cancelling.status, "cancelling");
+  assert.equal(cancelling.finishedAt, null);
+  const cancelled = await gtm(directory, env, ["runs", "get", toCancel.runKey, "--wait"]);
   assert.equal(cancelled.status, "cancelled");
   assert.equal(cancelled.runKey, toCancel.runKey);
   assert.notEqual(cancelled.finishedAt, null);
-  assert.match(cancelled.error, /operator stopped it/);
+  assert.match(cancelled.stopReason, /operator stopped it/);
   const cancelledAgain = await gtmFailure(directory, env, ["cancel", toCancel.runKey]);
   assert.equal(cancelledAgain.error.code, "run_not_active");
   const approveAfterCancel = await gtmFailure(directory, env, ["approve", toCancel.approval.token, "--yes"]);
-  assert.equal(approveAfterCancel.error.code, "not_found");
+  assert.equal(approveAfterCancel.error.code, "approval_not_pending");
   assert.equal((await gtm(directory, env, ["runs", "get", toCancel.runKey])).status, "cancelled");
   assert.equal((await tableRows(directory, env, "approval_effects")).length, 1);
   const timed = await startAndWait(directory, env, "approval-proof", { case: "timeout", timeoutMs: 100 });
-  const timedDone = await waitForRun(directory, env, timed.runKey, "completed");
+  const timedDone = await waitForRun(directory, env, timed.runKey, "timed_out");
   assert.equal(timedDone.approval.approved, false);
   assert.equal(timedDone.approval.comment, "timeout");
+  assert.equal(timedDone.stopReason, "approval_timeout");
 
   const scheduledStart = await httpJson(`${env.GTM_BASE_URL}/api/run/scheduled-proof`, {
     headers: { authorization: `Bearer ${secret}` },
@@ -271,7 +374,7 @@ test("v9 templates pass the local, approval, scheduled, webhook, cancel, and san
   const scheduledDuplicate = await httpJson(`${env.GTM_BASE_URL}/api/run/scheduled-proof`, {
     headers: { authorization: `Bearer ${secret}` },
   }, 409);
-  assert.equal(scheduledDuplicate.error.code, "run_in_progress");
+  assert.equal(scheduledDuplicate.error.code, "already_ran_today");
   const scheduledInput = join(directory, "data/scheduled.json");
   await writeFile(scheduledInput, JSON.stringify({ date: "manual" }));
   const checkpointRefusal = await gtmFailure(directory, env, [
@@ -285,9 +388,31 @@ test("v9 templates pass the local, approval, scheduled, webhook, cancel, and san
   assert.equal(checkpointRefusal.error.code, "invalid_checkpoint");
   await gtm(directory, env, ["approve", scheduledWait.approval.token, "--no", "--wait"]);
 
+  const catchupDate = "2026-08-27";
+  const catchup = await gtm(directory, env, [
+    "run",
+    "scheduled-proof",
+    "--input",
+    scheduledInput,
+    "--scheduled-for",
+    catchupDate,
+  ]);
+  const catchupWait = await waitForRun(directory, env, catchup.runKey, "waiting");
+  assert.equal(catchupWait.scheduledFor, catchupDate);
+  await gtm(directory, env, ["approve", catchupWait.approval.token, "--no", "--wait"]);
+
+  const concurrentDate = "2026-08-26";
   const concurrent = await Promise.all([
-    fetch(`${env.GTM_BASE_URL}/api/run/scheduled-proof`, { headers: { authorization: `Bearer ${secret}` } }),
-    fetch(`${env.GTM_BASE_URL}/api/run/scheduled-proof`, { headers: { authorization: `Bearer ${secret}` } }),
+    fetch(`${env.GTM_BASE_URL}/api/run/scheduled-proof?scheduled-for=${concurrentDate}`, {
+      method: "POST",
+      headers: { authorization: `Bearer ${secret}`, "content-type": "application/json", "x-gtm-workspace-head": deploymentHead },
+      body: JSON.stringify({ date: "concurrent" }),
+    }),
+    fetch(`${env.GTM_BASE_URL}/api/run/scheduled-proof?scheduled-for=${concurrentDate}`, {
+      method: "POST",
+      headers: { authorization: `Bearer ${secret}`, "content-type": "application/json", "x-gtm-workspace-head": deploymentHead },
+      body: JSON.stringify({ date: "concurrent" }),
+    }),
   ]);
   assert.deepEqual(concurrent.map((response) => response.status).sort(), [200, 409]);
   const concurrentBodies = await Promise.all(concurrent.map((response) => response.json()));
@@ -295,19 +420,58 @@ test("v9 templates pass the local, approval, scheduled, webhook, cancel, and san
   const concurrentWait = await waitForRun(directory, env, concurrentStart.runKey, "waiting");
   await gtm(directory, env, ["approve", concurrentWait.approval.token, "--no", "--wait"]);
 
-  const webhook = await startAndWait(directory, env, "webhook-proof", { event: "fixture" });
-  const webhookUrl = new URL(webhook.webhook_url);
-  assert.equal(webhookUrl.port, String(nitroPort));
-  assert.match(webhookUrl.pathname, /^\/\.well-known\/workflow\/v1\/webhook\//);
-  await waitForHook(directory, env, webhook.runId);
-  if (Number(process.versions.node.split(".")[0]) < 24) {
-    const webhookResponse = await fetch(webhook.webhook_url, { method: "POST", body: JSON.stringify({ ok: true }) });
-    assert.equal(webhookResponse.status, 202, serverLog);
-    const webhookDone = await waitForRun(directory, env, webhook.runKey, "completed");
-    assert.equal(webhookDone.status, "completed");
-  } else {
-    context.diagnostic("Webhook resume is deferred on Node 24; the scaffold pins Node 22 for this SDK release.");
-  }
+  const triggered = await startAndWait(directory, env, "trigger-proof", { event: "fixture" });
+  assert.equal(typeof triggered.trigger_token, "string");
+  const unauthenticatedTrigger = await fetch(`${env.GTM_BASE_URL}/api/runs/${triggered.runKey}/trigger`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ ok: true }),
+  });
+  assert.equal(unauthenticatedTrigger.status, 401);
+  const triggerResponse = await httpJson(`${env.GTM_BASE_URL}/api/runs/${triggered.runKey}/trigger`, {
+    method: "POST",
+    headers: { authorization: `Bearer ${secret}` },
+    body: JSON.stringify({ ok: true }),
+  });
+  assert.equal(triggerResponse.accepted, true);
+  assert.equal((await waitForRun(directory, env, triggered.runKey, "completed")).status, "completed");
+
+  const slowInput = join(directory, "data/slow.json");
+  await writeFile(slowInput, JSON.stringify({ rows: [{ key: "slow", domain: "slow.test" }] }));
+  const slow = await gtm(directory, env, ["run", "slow-proof", "--input", slowInput]);
+  await waitForLedgerStatus(directory, env, slow.runKey, "pending");
+  const slowCancelling = await gtm(directory, env, ["cancel", slow.runKey, "--reason", "fixture cancellation"]);
+  assert.equal(slowCancelling.status, "cancelling");
+  assert.equal(slowCancelling.finishedAt, null);
+  const slowDuplicate = await gtmFailure(directory, env, ["run", "slow-proof", "--input", slowInput]);
+  assert.equal(slowDuplicate.error.code, "run_in_progress");
+  const slowCancelled = await gtm(directory, env, ["runs", "get", slow.runKey, "--wait"]);
+  assert.equal(slowCancelled.status, "cancelled");
+  assert.notEqual(slowCancelled.finishedAt, null);
+
+  const errorInput = join(directory, "data/error.json");
+  await writeFile(errorInput, JSON.stringify({ key: "error" }));
+  const errorDone = await gtm(directory, env, ["run", "error-proof", "--input", errorInput, "--wait"]);
+  const errorText = JSON.stringify(errorDone);
+  assert.equal(errorDone.status, "failed");
+  assert.equal(errorDone.failedStep, "failWithCredential");
+  assert.doesNotMatch(errorText, /credential-to-redact/);
+  assert.doesNotMatch(errorText, /api_key=/i);
+  const errorLedger = await sqlRows(directory, env, `select error from enrichment_runs where run_key = '${errorDone.runKey}'`);
+  assert.doesNotMatch(JSON.stringify(errorLedger), /credential-to-redact/);
+
+  const agentCountBeforeContext = (await readFile(fakeCount, "utf8")).length;
+  await agentProbe(directory, env, { runKey: "context-a", context: "ICP alpha" });
+  await agentProbe(directory, env, { runKey: "context-b", context: "ICP beta" });
+  await agentProbe(directory, env, { runKey: "context-b-hit", context: "ICP beta" });
+  assert.equal((await readFile(fakeCount, "utf8")).length - agentCountBeforeContext, 2);
+
+  await assertNonEnforcingBackendStopsBeforeSpawn(directory, env);
+  await assertMissingCliCostsZero(directory, env);
+  await assertCacheParseFailureLedger(directory, env);
+  await assertLostPendingReconcile(directory, env);
+  await assertPartialUpsertMerge(directory, env);
+  await assertCommandPermissions(repo);
 
   const sandboxFile = await commandFailure(
     process.execPath,
@@ -326,6 +490,7 @@ test("v9 templates pass the local, approval, scheduled, webhook, cancel, and san
     { cwd: directory, env: { ...env, GTM_SANDBOX: "1", GTM_AGENT_BACKEND: "claude" } },
   );
   assert.match(sandboxBackend.stderr, /requires GTM_AGENT_BACKEND=api/);
+  await assertDirtyProductionStartRefused(directory, env, inputFile, nitroPort);
 });
 
 async function gtm(directory, env, args) {
@@ -362,6 +527,16 @@ async function waitForHook(directory, env, runId) {
     await new Promise((resolvePromise) => setTimeout(resolvePromise, 100));
   }
   throw new Error(`run ${runId} did not register its webhook hook`);
+}
+
+async function waitForLedgerStatus(directory, env, runKey, status) {
+  const deadline = Date.now() + 20_000;
+  while (Date.now() < deadline) {
+    const rows = await sqlRows(directory, env, `select status from enrichment_runs where run_key = '${runKey}'`);
+    if (rows.some((row) => row.status === status)) return;
+    await new Promise((resolvePromise) => setTimeout(resolvePromise, 100));
+  }
+  throw new Error(`run ${runKey} did not record ledger status ${status}`);
 }
 
 async function ledgerCount(directory, env) {
@@ -419,6 +594,175 @@ async function providerProbe(directory, env, options) {
     env,
   });
   return JSON.parse(result.stdout);
+}
+
+async function agentProbe(directory, env, options) {
+  const script = `
+    const [{ agent }, { z }] = await Promise.all([import("./lib/agent.ts"), import("zod")]);
+    const value = await agent({
+      prompt: "Context cache fixture",
+      context: ${JSON.stringify(options.context)},
+      contextId: "icps/fixture.md",
+      schema: z.object({ score: z.number(), reason: z.string() }),
+      tools: "none",
+      maxUsd: 0.08,
+      meta: { runKey: ${JSON.stringify(options.runKey)}, slug: "agent-probe" },
+    });
+    process.stdout.write(JSON.stringify(value));
+  `;
+  return command(process.execPath, ["--import", "tsx", "--input-type=module", "-e", script], { cwd: directory, env });
+}
+
+async function assertNonEnforcingBackendStopsBeforeSpawn(directory, env) {
+  const marker = join(directory, "codex-spawned");
+  const fakeCodex = join(directory, "fake-bin/codex");
+  await writeFile(fakeCodex, `#!/bin/sh\nprintf spawned > "${marker}"\n`);
+  await chmod(fakeCodex, 0o755);
+  const script = `
+    const [{ agent }, { z }] = await Promise.all([import("./lib/agent.ts"), import("zod")]);
+    await agent({ prompt: "untrusted", schema: z.object({ ok: z.boolean() }), tools: "none", meta: { runKey: "unsafe-backend", slug: "agent-probe" } });
+  `;
+  const result = await commandFailure(process.execPath, ["--import", "tsx", "--input-type=module", "-e", script], {
+    cwd: directory,
+    env: { ...env, GTM_AGENT_BACKEND: "codex" },
+  });
+  assert.match(result.stderr, /cannot enforce tools/);
+  await assert.rejects(readFile(marker));
+}
+
+async function assertMissingCliCostsZero(directory, env) {
+  const emptyPath = join(directory, "empty-path");
+  await mkdir(emptyPath);
+  const script = `
+    const [{ agent }, { z }] = await Promise.all([import("./lib/agent.ts"), import("zod")]);
+    await agent({ prompt: "missing cli", schema: z.object({ ok: z.boolean() }), tools: "none", maxUsd: 0.5, meta: { runKey: "missing-cli", slug: "agent-probe" } });
+  `;
+  await commandFailure(process.execPath, ["--import", "tsx", "--input-type=module", "-e", script], {
+    cwd: directory,
+    env: { ...env, PATH: emptyPath, GTM_AGENT_BACKEND: "claude" },
+  });
+  const rows = await sqlRows(directory, env, "select status, cost_usd, error_kind from enrichment_runs where run_key = 'missing-cli'");
+  assert.deepEqual(rows, [{ status: "error", cost_usd: 0, error_kind: "pre_call" }]);
+}
+
+async function assertCacheParseFailureLedger(directory, env) {
+  const script = `
+    const [{ createHash }, { provider }, { getDb }, { enrichmentCache }, { z }] = await Promise.all([
+      import("node:crypto"), import("./lib/provider.ts"), import("./lib/db.ts"), import("./lib/schema.ts"), import("zod")
+    ]);
+    const input = { domain: "bad-cache.test" };
+    const hash = createHash("sha256").update(JSON.stringify(input)).digest("hex");
+    await (await getDb()).insert(enrichmentCache).values({ provider: "bad-cache", endpoint: "lookup", inputsHash: hash, inputs: JSON.stringify(input), raw: "{}", value: "{}", expiresAt: Date.now() + 10000, createdAt: Date.now() });
+    try {
+      await provider({ name: "bad-cache", endpoint: "lookup", input, schema: z.object({ company: z.string() }), ttlMs: 10000, call: async () => ({ company: "never" }), meta: { runKey: "cache-parse", slug: "provider-probe" } });
+    } catch {}
+  `;
+  await command(process.execPath, ["--import", "tsx", "--input-type=module", "-e", script], { cwd: directory, env });
+  const rows = await sqlRows(directory, env, "select status, error_kind from enrichment_runs where run_key = 'cache-parse'");
+  assert.deepEqual(rows, [{ status: "error", error_kind: "cache_parse" }]);
+}
+
+async function assertLostPendingReconcile(directory, env) {
+  const script = `
+    const [{ randomUUID }, { getDb, reconcileRun }, { enrichmentRuns, workflowRuns }] = await Promise.all([
+      import("node:crypto"), import("./lib/db.ts"), import("./lib/schema.ts")
+    ]);
+    const db = await getDb();
+    await db.insert(workflowRuns).values({ runKey: "lost-run", runId: "missing-sdk-run", workflow: "lost", path: "lost", method: "POST", input: "{}", inputHash: "lost-hash", status: "running", startedAt: Date.now() });
+    await db.insert(enrichmentRuns).values({ id: randomUUID(), runKey: "lost-run", workflow: "lost", provider: "fixture", endpoint: "lookup", inputsHash: "hash", status: "pending", costUsd: 0.4, costSource: "fixed", createdAt: Date.now() });
+    await reconcileRun("lost-run");
+    await db.insert(workflowRuns).values({ runKey: "never-started", runId: null, workflow: "never", path: "never", method: "POST", input: "{}", inputHash: "never-hash", status: "running", startedAt: Date.now() - 601000 });
+    await reconcileRun("never-started");
+  `;
+  await command(process.execPath, ["--import", "tsx", "--input-type=module", "-e", script], { cwd: directory, env });
+  const ledger = await sqlRows(directory, env, "select status, cost_usd, error_kind from enrichment_runs where run_key = 'lost-run'");
+  assert.deepEqual(ledger, [{ status: "lost", cost_usd: 0.4, error_kind: "lost" }]);
+  const run = await sqlRows(directory, env, "select status, cost_usd from workflow_runs where run_key = 'lost-run'");
+  assert.deepEqual(run, [{ status: "failed", cost_usd: 0.4 }]);
+  const neverStarted = await sqlRows(directory, env, "select status, error from workflow_runs where run_key = 'never-started'");
+  assert.deepEqual(neverStarted, [{ status: "failed", error: "start not recorded" }]);
+}
+
+async function assertPartialUpsertMerge(directory, env) {
+  const script = `
+    const [{ upsertRows }, { mergeRows }] = await Promise.all([import("./lib/db.ts"), import("./db/tables/accounts.ts")]);
+    await upsertRows(mergeRows, [{ key: "merge", alpha: "A", updatedAt: 1 }]);
+    await upsertRows(mergeRows, [{ key: "merge", beta: "B", updatedAt: 2 }]);
+  `;
+  await command(process.execPath, ["--import", "tsx", "--input-type=module", "-e", script], { cwd: directory, env });
+  const rows = await sqlRows(directory, env, "select key, alpha, beta, updated_at from merge_rows");
+  assert.deepEqual(rows, [{ key: "merge", alpha: "A", beta: "B", updated_at: 2 }]);
+}
+
+async function assertCommandPermissions(repo) {
+  const script = join(repo, "skills/gtm-workflow/scripts/command-permission.mjs");
+  const cases = [
+    ["npm run gtm -- check", "allow"],
+    ["npm run gtm -- query --sql 'SELECT 1'", "allow"],
+    ["npm run gtm -- runs get abc", "allow"],
+    ["npm run gtm -- run proof --input rows.json --dry-run", "allow"],
+    ["npx workflow inspect runs", "allow"],
+    ["npm run db:studio:cloud", "allow"],
+    ["npm run gtm -- run proof --input rows.json", "ask"],
+    ["npm run gtm -- approve token --yes", "ask"],
+    ["npm run db:migrate", "ask"],
+    ["vercel deploy", "ask"],
+    ["npm run gtm -- check; npm run gtm -- run proof", "ask"],
+    ["npm run gtm -- query --sql $SQL", "ask"],
+  ];
+  for (const [sample, expected] of cases) {
+    const result = await command(process.execPath, [script, "--classify", sample], { cwd: repo, env: process.env });
+    assert.equal(JSON.parse(result.stdout).decision, expected, sample);
+  }
+}
+
+async function assertCheckRules(directory, env) {
+  const localPath = join(directory, "workflows/local-proof.ts");
+  const triggerPath = join(directory, "workflows/trigger-proof.ts");
+  const tablePath = join(directory, "db/tables/accounts.ts");
+  const migrationPath = join(directory, "drizzle/0002_abandoned_quentin_quire.sql");
+  const providerPath = join(directory, "lib/provider.ts");
+
+  await expectCheckViolation(localPath, (source) => source.replace("enrichAccount.maxRetries = 0;", ""), "paid_step_retries", directory, env);
+  await expectCheckViolation(localPath, (source) => source.replace('  arg = input.parse(arg);', '  arg = input.parse(arg);\n  Date.now();'), "nondeterministic_workflow", directory, env);
+  await expectCheckViolation(triggerPath, (source) => source.replace('  await updateRun(meta.runKey, { status: "completed", completed: 1, failed: 0, cost_usd: 0, finished: true });', '  return arg;'), "missing_terminal_bookkeeping", directory, env);
+  await expectCheckViolation(triggerPath, (source) => `${source}\nconst forbiddenAtModuleScope = fetch("https://invalid.test");\n`, "invalid_module_scope", directory, env);
+  await expectCheckViolation(tablePath, (source) => source.replaceAll(".primaryKey()", ""), "invalid_result_table", directory, env);
+  await expectCheckViolation(migrationPath, (source) => `${source}\nDELETE FROM workflow_runs;\n`, "destructive_migration", directory, env);
+  await expectCheckViolation(migrationPath, (source) => `${source}\nALTER TABLE workflow_runs RENAME TO old_workflow_runs;\n`, "destructive_migration", directory, env);
+  await expectCheckViolation(providerPath, (source) => source.replace("// gtm-lib v10\n", "// gtm-lib v10\n\n"), "lib_modified", directory, env);
+}
+
+async function assertDirtyProductionStartRefused(directory, env, inputFile, nitroPort) {
+  const workflowPath = join(directory, "workflows/local-proof.ts");
+  const packagePath = join(directory, "package.json");
+  const workflow = (await readFile(workflowPath, "utf8")).replace("Runs: on this computer", "Runs: on Vercel");
+  const packageJson = JSON.parse(await readFile(packagePath, "utf8"));
+  packageJson.gtm.vercel = { url: `http://127.0.0.1:${nitroPort}` };
+  await writeFile(workflowPath, workflow);
+  await writeFile(packagePath, `${JSON.stringify(packageJson, null, 2)}\n`);
+  await command("git", ["init", "-q"], { cwd: directory, env });
+  await command("git", ["config", "user.email", "fixture@example.invalid"], { cwd: directory, env });
+  await command("git", ["config", "user.name", "Fixture"], { cwd: directory, env });
+  await command("git", ["add", "-A"], { cwd: directory, env });
+  await command("git", ["commit", "-qm", "fixture"], { cwd: directory, env });
+  await writeFile(join(directory, "dirty-workspace"), "dirty\n");
+  const cleanEnv = { ...env };
+  delete cleanEnv.GTM_BASE_URL;
+  delete cleanEnv.VERCEL_GIT_COMMIT_SHA;
+  const refused = await gtmFailure(directory, cleanEnv, ["run", "local-proof", "--input", inputFile]);
+  assert.equal(refused.error.code, "deployment_workspace_dirty");
+}
+
+async function expectCheckViolation(path, mutate, code, directory, env) {
+  const source = await readFile(path, "utf8");
+  await writeFile(path, mutate(source));
+  try {
+    const result = await gtmFailure(directory, env, ["check"]);
+    assert.equal(result.error.code, code, `${relative(directory, path)} should fail ${code}`);
+  } finally {
+    await writeFile(path, source);
+  }
 }
 
 async function httpJson(url, init = {}, expectedStatus = 200) {
@@ -496,6 +840,13 @@ export const approvalEffects = sqliteTable("approval_effects", {
   key: text("key").primaryKey(),
   updatedAt: integer("updated_at").notNull(),
 });
+
+export const mergeRows = sqliteTable("merge_rows", {
+  key: text("key").primaryKey(),
+  alpha: text("alpha"),
+  beta: text("beta"),
+  updatedAt: integer("updated_at").notNull(),
+});
 `;
 
 const localWorkflow = `/**
@@ -510,10 +861,10 @@ import { z } from "zod";
 import { createInsertSchema } from "drizzle-zod";
 import { accounts } from "../db/tables/accounts";
 import { agent } from "../lib/agent";
-import { checkpoint, type WorkflowMeta } from "../lib/approve";
+import type { WorkflowMeta } from "../lib/approve";
 import { upsertRows } from "../lib/db";
 import { provider } from "../lib/provider";
-import { updateRun } from "../lib/steps";
+import { runRows } from "../lib/rows";
 
 export const input = z.object({ rows: z.array(z.object({ key: z.string(), domain: z.string() })) });
 type Input = z.infer<typeof input>;
@@ -521,7 +872,7 @@ export const MAX_ROWS = 25;
 export const MAX_SPEND_USD = 5;
 export const COST_PER_ROW_USD = 0.1;
 
-async function enrichAccount(row: Input["rows"][number], meta: WorkflowMeta) {
+async function enrichAccount(row: Input["rows"][number], meta: WorkflowMeta, signal: AbortSignal) {
   "use step";
   const vendor = await provider({
     name: "mock-data",
@@ -531,7 +882,7 @@ async function enrichAccount(row: Input["rows"][number], meta: WorkflowMeta) {
     ttlMs: 86400000,
     costUsd: 0.02,
     call: async () => {
-      const response = await fetch(process.env.MOCK_VENDOR_URL + "?domain=" + encodeURIComponent(row.domain));
+      const response = await fetch(process.env.MOCK_VENDOR_URL + "?domain=" + encodeURIComponent(row.domain), { signal });
       const raw = await response.json();
       return { raw, value: raw };
     },
@@ -541,50 +892,33 @@ async function enrichAccount(row: Input["rows"][number], meta: WorkflowMeta) {
   const rowSchema = createInsertSchema(accounts).pick({ score: true, reason: true });
   const scored = await agent({
     prompt: "Score " + vendor.value.company,
+    context: "Accepted ICP: fixture companies.",
+    contextId: "icps/fixture.md",
     schema: rowSchema,
     tools: "none",
     maxUsd: 0.08,
     meta,
+    signal,
   });
-  return { key: row.key, company: vendor.value.company, ...scored, costUsd: vendor.costUsd + 0.08 };
+  return { key: row.key, value: { company: vendor.value.company, ...scored } };
 }
 enrichAccount.maxRetries = 0;
 
 async function saveAccount(row: Record<string, unknown>) {
   "use step";
-  await upsertRows(accounts, [row]);
+  await upsertRows(accounts, [{ ...row, updatedAt: Date.now() }]);
 }
 
 export async function localProof(arg: Input, meta: WorkflowMeta) {
   "use workflow";
   arg = input.parse(arg);
-  const projected = arg.rows.length * COST_PER_ROW_USD;
-  if (arg.rows.length > MAX_ROWS || projected > MAX_SPEND_USD) throw new Error("Accepted workflow limits exceeded");
-  const completed: string[] = [];
-  const failed: { key: string; error: string }[] = [];
-  let spentUsd = 0;
-  for (const row of arg.rows) {
-    try {
-      const result = await enrichAccount(row, meta);
-      spentUsd += result.costUsd;
-      await saveAccount({ ...result, costUsd: undefined, updatedAt: Date.now() });
-      completed.push(row.key);
-    } catch (error) {
-      failed.push({ key: row.key, error: String(error) });
-    }
-    if (completed.length + failed.length === meta.checkpoint) {
-      const decision = await checkpoint(meta, {
-        completed: completed.length,
-        failed: failed.length,
-        spentUsd,
-        projectedRemainingUsd: (arg.rows.length - completed.length - failed.length) * COST_PER_ROW_USD,
-        table: "accounts",
-      });
-      if (!decision.approved) break;
-    }
-  }
-  await updateRun(meta.runKey, { status: "completed", completed: completed.length, failed: failed.length, cost_usd: spentUsd, finished: true });
-  return { completed, failed };
+  return runRows({
+    rows: arg.rows,
+    meta,
+    table: { name: "accounts", save: saveAccount },
+    rowStep: enrichAccount,
+    caps: { maxRows: MAX_ROWS, maxSpendUsd: MAX_SPEND_USD, costPerRowUsd: COST_PER_ROW_USD },
+  });
 }
 `;
 
@@ -615,7 +949,7 @@ export async function approvalProof(arg: Input, meta: WorkflowMeta) {
   arg = input.parse(arg);
   const decision = await approve({ stage: "outreach", summary: "Approve fixture side effect", meta, timeoutMs: arg.timeoutMs });
   if (decision.approved) await recordApproval(arg.case);
-  await updateRun(meta.runKey, { status: "completed", completed: decision.approved ? 1 : 0, failed: 0, cost_usd: 0, finished: true });
+  await updateRun(meta.runKey, { status: decision.outcome === "approved" ? "completed" : decision.outcome === "timed_out" ? "timed_out" : "stopped", completed: decision.approved ? 1 : 0, failed: 0, cost_usd: 0, finished: true });
   return decision;
 }
 `;
@@ -641,36 +975,165 @@ export async function scheduledProof(arg: Input, meta: WorkflowMeta) {
   "use workflow";
   arg ??= scheduledInput;
   arg = input.parse(arg);
-  await approve({ stage: "scheduled", summary: "Hold scheduled fixture", meta });
-  await updateRun(meta.runKey, { status: "completed", completed: 1, failed: 0, cost_usd: 0, finished: true });
+  const decision = await approve({ stage: "scheduled", summary: "Hold scheduled fixture", meta });
+  await updateRun(meta.runKey, { status: decision.approved ? "completed" : "stopped", completed: decision.approved ? 1 : 0, failed: 0, cost_usd: 0, finished: true });
   return arg;
 }
 `;
 
-const webhookWorkflow = `/**
- * Proves a per-run webhook pause.
+const triggerWorkflow = `/**
+ * Proves an authorized trigger pause.
  * Runs: on Vercel
  * Kind: triggered
  * Owner: Fixture | ICP: Fixture
  * Providers: none
  */
-import { createWebhook } from "workflow";
 import { z } from "zod";
-import type { WorkflowMeta } from "../lib/approve";
+import { waitForTrigger, type WorkflowMeta } from "../lib/approve";
 import { updateRun } from "../lib/steps";
 export const input = z.object({ event: z.string() });
+const payload = z.object({ ok: z.boolean() });
 type Input = z.infer<typeof input>;
 export const MAX_ROWS = 1;
 export const MAX_SPEND_USD = 0;
 export const COST_PER_ROW_USD = 0;
-export async function webhookProof(arg: Input, meta: WorkflowMeta) {
+export async function triggerProof(arg: Input, meta: WorkflowMeta) {
   "use workflow";
   arg = input.parse(arg);
-  const webhook = createWebhook();
-  await updateRun(meta.runKey, { status: "waiting", webhook_url: webhook.url });
-  await webhook;
-  await updateRun(meta.runKey, { status: "running" });
+  payload.parse(await waitForTrigger(meta));
   await updateRun(meta.runKey, { status: "completed", completed: 1, failed: 0, cost_usd: 0, finished: true });
   return arg;
+}
+`;
+
+const slowWorkflow = `/**
+ * Proves cancelling keeps the duplicate guard closed during a paid step.
+ * Runs: on this computer
+ * Kind: on-demand
+ * Owner: Fixture | ICP: Fixture
+ * Providers: mock-data slow-lookup $0.02 per row
+ * Table: accounts | key: fixture account id
+ */
+import { z } from "zod";
+import { accounts } from "../db/tables/accounts";
+import type { WorkflowMeta } from "../lib/approve";
+import { upsertRows } from "../lib/db";
+import { provider } from "../lib/provider";
+import { runRows } from "../lib/rows";
+export const input = z.object({ rows: z.array(z.object({ key: z.string(), domain: z.string() })) });
+type Input = z.infer<typeof input>;
+export const MAX_ROWS = 1;
+export const MAX_SPEND_USD = 1;
+export const COST_PER_ROW_USD = 0.02;
+async function slowLookup(row: Input["rows"][number], meta: WorkflowMeta) {
+  "use step";
+  const result = await provider({
+    name: "mock-data", endpoint: "slow-lookup", input: { domain: row.domain }, schema: z.object({ company: z.string() }), ttlMs: 1000, costUsd: 0.02,
+    call: async () => (await fetch(process.env.MOCK_VENDOR_URL + "?domain=" + encodeURIComponent(row.domain))).json(), meta,
+  });
+  return { key: row.key, value: { company: result.value.company, score: 1, reason: "slow" } };
+}
+slowLookup.maxRetries = 0;
+async function saveSlow(row: Record<string, unknown>) { "use step"; await upsertRows(accounts, [{ ...row, updatedAt: Date.now() }]); }
+export async function slowProof(arg: Input, meta: WorkflowMeta) {
+  "use workflow";
+  arg = input.parse(arg);
+  return runRows({ rows: arg.rows, meta, table: { name: "accounts", save: saveSlow }, rowStep: slowLookup, caps: { maxRows: MAX_ROWS, maxSpendUsd: MAX_SPEND_USD, costPerRowUsd: COST_PER_ROW_USD } });
+}
+`;
+
+const errorWorkflow = `/**
+ * Proves defensive error redaction.
+ * Runs: on this computer
+ * Kind: on-demand
+ * Owner: Fixture | ICP: Fixture
+ * Providers: error-vendor lookup $0.02 per row
+ */
+import { z } from "zod";
+import type { WorkflowMeta } from "../lib/approve";
+import { provider } from "../lib/provider";
+import { updateRun } from "../lib/steps";
+export const input = z.object({ key: z.string() });
+type Input = z.infer<typeof input>;
+export const MAX_ROWS = 1;
+export const MAX_SPEND_USD = 1;
+export const COST_PER_ROW_USD = 0.02;
+async function failWithCredential(_key: string, meta: WorkflowMeta) {
+  "use step";
+  return provider({ name: "error-vendor", endpoint: "lookup", input: {}, schema: z.object({ ok: z.boolean() }), ttlMs: 1000, costUsd: 0.02, call: async () => { throw new Error("request failed https://vendor.invalid/path?api_key=" + process.env.FIXTURE_API_TOKEN); }, meta });
+}
+failWithCredential.maxRetries = 0;
+export async function errorProof(arg: Input, meta: WorkflowMeta) {
+  "use workflow";
+  arg = input.parse(arg);
+  try { await failWithCredential(arg.key, meta); }
+  catch (error) { await updateRun(meta.runKey, { status: "failed", error: String(error), failed_step: "failWithCredential", finished: true }); throw error; }
+  await updateRun(meta.runKey, { status: "completed", completed: 1, failed: 0, finished: true });
+}
+`;
+
+const spendWorkflow = `/**
+ * Proves the ledger-based mid-run spend stop.
+ * Runs: on this computer
+ * Kind: on-demand
+ * Owner: Fixture | ICP: Fixture
+ * Providers: mock-data spend-lookup $0.03 per row
+ * Table: accounts | key: fixture account id
+ */
+import { z } from "zod";
+import { accounts } from "../db/tables/accounts";
+import type { WorkflowMeta } from "../lib/approve";
+import { upsertRows } from "../lib/db";
+import { provider } from "../lib/provider";
+import { runRows } from "../lib/rows";
+export const input = z.object({ rows: z.array(z.object({ key: z.string(), domain: z.string() })) });
+type Input = z.infer<typeof input>;
+export const MAX_ROWS = 5;
+export const MAX_SPEND_USD = 0.05;
+export const COST_PER_ROW_USD = 0.01;
+async function spendLookup(row: Input["rows"][number], meta: WorkflowMeta) {
+  "use step";
+  const result = await provider({ name: "mock-data", endpoint: "spend-lookup", input: { domain: row.domain }, schema: z.object({ company: z.string() }), ttlMs: 1000, costUsd: 0.03, call: async () => (await fetch(process.env.MOCK_VENDOR_URL + "?domain=" + encodeURIComponent(row.domain))).json(), meta });
+  return { key: row.key, value: { company: result.value.company, score: 1, reason: "spend" } };
+}
+spendLookup.maxRetries = 0;
+async function saveSpend(row: Record<string, unknown>) { "use step"; await upsertRows(accounts, [{ ...row, updatedAt: Date.now() }]); }
+export async function spendProof(arg: Input, meta: WorkflowMeta) {
+  "use workflow";
+  arg = input.parse(arg);
+  return runRows({ rows: arg.rows, meta, table: { name: "accounts", save: saveSpend }, rowStep: spendLookup, caps: { maxRows: MAX_ROWS, maxSpendUsd: MAX_SPEND_USD, costPerRowUsd: COST_PER_ROW_USD } });
+}
+`;
+
+const heldWorkflow = `/**
+ * Proves authentication failures hold the run.
+ * Runs: on this computer
+ * Kind: on-demand
+ * Owner: Fixture | ICP: Fixture
+ * Providers: held-vendor lookup $0.01 per row
+ * Table: accounts | key: fixture account id
+ */
+import { z } from "zod";
+import { accounts } from "../db/tables/accounts";
+import type { WorkflowMeta } from "../lib/approve";
+import { upsertRows } from "../lib/db";
+import { provider, ProviderAuthError } from "../lib/provider";
+import { runRows } from "../lib/rows";
+export const input = z.object({ rows: z.array(z.object({ key: z.string() })) });
+type Input = z.infer<typeof input>;
+export const MAX_ROWS = 5;
+export const MAX_SPEND_USD = 1;
+export const COST_PER_ROW_USD = 0.01;
+async function heldLookup(row: Input["rows"][number], meta: WorkflowMeta) {
+  "use step";
+  const result = await provider({ name: "held-vendor", endpoint: "lookup", input: { key: row.key }, schema: z.object({ company: z.string() }), ttlMs: 1000, costUsd: 0.01, call: async () => { if (row.key === "held-1") throw new ProviderAuthError("credential rejected"); return { company: row.key }; }, meta });
+  return { key: row.key, value: { company: result.value.company, score: 1, reason: "held" } };
+}
+heldLookup.maxRetries = 0;
+async function saveHeld(row: Record<string, unknown>) { "use step"; await upsertRows(accounts, [{ ...row, updatedAt: Date.now() }]); }
+export async function heldProof(arg: Input, meta: WorkflowMeta) {
+  "use workflow";
+  arg = input.parse(arg);
+  return runRows({ rows: arg.rows, meta, table: { name: "accounts", save: saveHeld }, rowStep: heldLookup, caps: { maxRows: MAX_ROWS, maxSpendUsd: MAX_SPEND_USD, costPerRowUsd: COST_PER_ROW_USD } });
 }
 `;

--- a/skills/gtm-workflow/SKILL.md
+++ b/skills/gtm-workflow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gtm-workflow
-description: Triggers when a user wants to create, update, inspect, delete, run, approve, query, schedule, trigger, or deploy a saved GTM workflow in a GTM workspace, including typed result tables, paid provider or model calls, dry runs, checkpoints, webhooks, and Vercel Workflows. Not for creating or repairing the workspace itself, ICP or persona lifecycle work, other workflow engines, or one-off calls that are not saved as workflows.
+description: Triggers when a user wants to create, update, inspect, delete, run, approve, query, schedule, trigger, or deploy a saved GTM workflow in a GTM workspace, including typed result tables, paid provider or model calls, dry runs, checkpoints, authorized triggers, and Vercel Workflows. Not for creating or repairing the workspace itself, ICP or persona lifecycle work, other workflow engines, or one-off calls that are not saved as workflows.
 ---
 
 # GTM workflow
@@ -45,7 +45,8 @@ Report a run still active after the bounded poll so `gtm runs get` can retrieve 
 ## QC
 
 - Secrets never appear in prompts, tracked files, conversation, or command output; values move from `.env` through the shell only.
-- Compare every `// gtm-lib v9` header with the template before an action. Offer a recopy when versions differ and never apply it silently.
+- Before editing any workflow or managed library file, read the pinned runtime's bundled documentation under `workflows/node_modules/workflow/docs/`; assume prior SDK knowledge is outdated.
+- Run `gtm check` and compare every `// gtm-lib v10` header and recorded content hash before an action. Show locally modified diffs, offer a recopy, and never apply it silently.
 - Copy the versioned lib, routes, scripts, and config verbatim and edit workflow-owned tables, adapters, migrations, and workflow files instead.
 - Route every paid vendor call through `provider()` and every model call through `agent()`.
 - Use committed migrations. The project has no `db:push` command.

--- a/skills/gtm-workflow/references/agents.md
+++ b/skills/gtm-workflow/references/agents.md
@@ -1,55 +1,64 @@
 # Agent command permissions
 
-These snippets allow the narrow command prefixes used by the workflow skill. Review them before adding them to a user-level agent configuration. Keep file edits, Git actions, and arbitrary shell commands outside this list.
+Install the shipped classifier instead of broadly allowing the GTM CLI. It parses shell quoting and returns `allow` only for read-only inspection and zero-spend dry runs. It returns `ask` for real runs, decisions, cancellation, migrations, deployment, unknown commands, and commands containing substitution, chaining, redirects, escapes, or background operators.
 
-## Claude Code
+## Command hook
 
-Add the required entries under `permissions.allow` in `settings.json`:
+The classifier is `skills/gtm-workflow/scripts/command-permission.mjs`. Test a command before installation:
+
+```text
+node <skill-path>/scripts/command-permission.mjs --classify "npm run gtm -- check"
+```
+
+For a host with `PreToolUse` command hooks, attach it to Bash in the user's settings:
 
 ```json
 {
-  "permissions": {
-    "allow": [
-      "Bash(npm run gtm --:*)",
-      "Bash(npm run db:generate:*)",
-      "Bash(npm run db:migrate:*)",
-      "Bash(npm run db:migrate:cloud:*)",
-      "Bash(npm run db:studio:*)",
-      "Bash(npm run db:studio:cloud:*)",
-      "Bash(npx workflow inspect:*)",
-      "Bash(npx workflow validate:*)",
-      "Bash(npx workflow cancel:*)",
-      "Bash(npx workflow web:*)",
-      "Bash(npx drizzle-kit:*)",
-      "Bash(vercel:*)"
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node <skill-path>/scripts/command-permission.mjs"
+          }
+        ]
+      }
     ]
   }
 }
 ```
 
-## Codex
+The hook allows `gtm check`, `gtm query`, `gtm runs get`, `gtm run ... --dry-run`, `workflow inspect`, `workflow validate`, `db:generate`, `db:verify`, and both Studio commands. Everything else asks.
 
-Put the rules in a `.rules` file under the user's Codex rules directory. The `pattern` is an argv prefix, so keep each token separate:
+## Prefix-only hosts
+
+When a host supports only argv-prefix rules, use narrow rules and keep every mutating family at `prompt`:
 
 ```python
-prefix_rule(pattern=["npm", "run", "gtm", "--"], decision="allow")
+prefix_rule(pattern=["npm", "run", "gtm", "--", "check"], decision="allow")
+prefix_rule(pattern=["npm", "run", "gtm", "--", "query"], decision="allow")
+prefix_rule(pattern=["npm", "run", "gtm", "--", "runs", "get"], decision="allow")
 prefix_rule(pattern=["npm", "run", "db:generate"], decision="allow")
-prefix_rule(pattern=["npm", "run", "db:migrate"], decision="allow")
-prefix_rule(pattern=["npm", "run", "db:migrate:cloud"], decision="allow")
+prefix_rule(pattern=["npm", "run", "db:verify"], decision="allow")
 prefix_rule(pattern=["npm", "run", "db:studio"], decision="allow")
 prefix_rule(pattern=["npm", "run", "db:studio:cloud"], decision="allow")
 prefix_rule(pattern=["npx", "workflow", "inspect"], decision="allow")
 prefix_rule(pattern=["npx", "workflow", "validate"], decision="allow")
-prefix_rule(pattern=["npx", "workflow", "cancel"], decision="allow")
-prefix_rule(pattern=["npx", "workflow", "web"], decision="allow")
-prefix_rule(pattern=["npx", "drizzle-kit"], decision="allow")
+prefix_rule(pattern=["npm", "run", "gtm", "--", "run"], decision="prompt")
+prefix_rule(pattern=["npm", "run", "gtm", "--", "approve"], decision="prompt")
+prefix_rule(pattern=["npm", "run", "gtm", "--", "cancel"], decision="prompt")
+prefix_rule(pattern=["npm", "run", "db:migrate"], decision="prompt")
+prefix_rule(pattern=["npm", "run", "db:migrate:cloud"], decision="prompt")
+prefix_rule(pattern=["npx", "workflow", "cancel"], decision="prompt")
 prefix_rule(pattern=["vercel"], decision="prompt")
 ```
 
-Keep Vercel at `prompt` because link, environment, integration, deploy, and removal commands change external state. The user still approves deployment through the skill's deployment gate.
+A prefix-only host cannot express “run only with `--dry-run`” safely, so every `gtm run` remains prompted there.
 
 ## Boundaries
 
-These rules do not make a real run, migration, deploy, approval, or destructive table change preapproved. They only let the agent invoke the bounded CLI after the skill's human gate has granted the action. Secrets still move through ignored environment files or shell input and never appear in an allowed command string.
+The hook prevents an unprompted real run; the skill's run gate provides the conversation and accepted scope. Neither mechanism preapproves migrations, deploys, approvals, cancellation, or destructive table changes. Secrets move through ignored environment files or brokered headers and never appear in command strings.
 
-A hosted agent may expose trusted run controls instead of the production-run commands above. Their read-only preview and status actions need no approval. Start, approval, and cancel require native approval after the skill's matching gate. A hosted sandbox starts no real run and holds a read-only database credential. The accepted `main` commit deploys through the workspace's Git-connected Vercel project; the host carries only the fixed production URL and run bearer, waits for the exact commit SHA, and never accepts production authority from model input.
+A hosted agent may expose trusted controls instead of production commands. Preview and status are read-only. Start, approval, cancellation, migration, and save remain approval-gated. The sandbox starts no real run and holds only read authority; the accepted `main` commit deploys through the connected project, while the host carries the fixed production URL and run bearer and waits for the exact commit SHA.

--- a/skills/gtm-workflow/references/contract.md
+++ b/skills/gtm-workflow/references/contract.md
@@ -2,219 +2,136 @@
 
 Use this contract for every workflow action.
 
-## Contents
-
-- [Workspace and ownership](#workspace-and-ownership)
-- [Project shape and state](#project-shape-and-state)
-- [Versioned files](#versioned-files)
-- [Workflow and table contract](#workflow-and-table-contract)
-- [Runtime and run identity](#runtime-and-run-identity)
-- [Paid calls](#paid-calls)
-- [Environment](#environment)
-- [House rules](#house-rules)
-- [Safety and persistence](#safety-and-persistence)
-
 ## Workspace and ownership
 
-Resolve the workspace in this order: a repository named in the request, the connected repository, then canonical repositories under `~/.gtm/` whose root has `ORG.md`. If several remain, ask which one to use and list its display name and path. If none exists, stop before writes and hand creation or connection to `gtm-workspace`.
+Resolve the workspace in this order: a repository named in the request, the connected repository, then canonical repositories under `~/.gtm/` whose root has `ORG.md`. If several remain, ask which one to use. If none exists, stop before writes and hand creation or connection to `gtm-workspace`.
 
-A named organization node wins. Otherwise use root unless the workflow belongs to exactly one suborganization. The project always lives at workspace root. Root workflows use `workflows/workflows/<slug>.ts`. Suborganization workflows use `workflows/workflows/<suborg-path>/<slug>.ts`, with physical `suborgs/` segments omitted.
-
-Before acting, state `Using GTM workspace: <display name> | <N> workflows visible`.
+A named organization node wins. Otherwise use root unless the workflow belongs to exactly one suborganization. The project always lives at workspace root. Root workflows use `workflows/workflows/<slug>.ts`; suborganization paths omit physical `suborgs/` segments. Before acting, state `Using GTM workspace: <display name> | <N> workflows visible`.
 
 ## Project shape and state
 
 ```text
 workflows/
-├── .env.example
-├── package.json
-├── package-lock.json
-├── nitro.config.ts
-├── drizzle.config.ts
+├── package.json, nitro.config.ts, drizzle.config.ts
 ├── drizzle/
 ├── workflows/<owner-path>/<slug>.ts
 ├── db/tables/<table>.ts
 ├── providers/<provider>.ts
-├── lib/{schema,db-url,db,steps,provider,agent,approve}.ts
-├── scripts/gtm.ts
-└── server/api/{deployment,run,runs,runs/[runId]/cancel,approve}/...
+├── lib/{schema,db-url,db,steps,provider,agent,approve,rows,redact,migration-ledger}.ts
+├── scripts/{gtm,migrate-cloud,verify-migrations}.ts
+└── server/api/{deployment,run,runs,runs/[runId]/{cancel,trigger},approve}/...
 ```
 
-Git owns definitions, table declarations, adapters, and migrations. Vercel owns steps, attempts, retries, graphs, and logs. The database owns business rows, the paid-call cache and ledger, and the run index. The database does not copy a step trace. Source and deployments can roll back. Schema and data do not roll back.
-
-The three fixed tables are `enrichment_cache`, `enrichment_runs`, and `workflow_runs`. A workflow declares its own result table. There is no shared entity or CRM schema.
+Git owns definitions, typed tables, adapters, and migrations. Vercel owns retained execution state, attempts, graphs, and logs. The database owns business rows, the paid-call cache and ledger, and the durable run index. Source can roll back; schema and data do not. The fixed tables are `enrichment_cache`, `enrichment_runs`, and `workflow_runs`; each workflow declares its own result table.
 
 Ignore `node_modules/`, `.env*` except `.env.example`, `.vercel/`, `.well-known/`, `.workflow-data/`, `.nitro/`, `.output/`, `.swc/`, and `data/`. Track `drizzle/`.
 
 ## Versioned files
 
-Every `lib/*.ts`, all five route files, `scripts/gtm.ts`, `scripts/migrate-cloud.ts`, `drizzle.config.ts`, and `nitro.config.ts` starts with `// gtm-lib v9`. `package.json` carries `gtm.libVersion: 9`. Compare these versions before every action. Name differing files and offer a template recopy in the proposal. Compare headers, not hashes, and never recopy silently.
+Every `lib/*.ts`, API route, managed script, `drizzle.config.ts`, and `nitro.config.ts` starts with `// gtm-lib v10`. `package.json` carries `gtm.libVersion: 10`, SHA-256 entries under `gtm.libHashes`, and pinned versions under `gtm.validatedAgainst`. Run `gtm check` before every action: distinguish an old header from a locally modified hash, show the diff of a modified managed file before offering a recopy, and never overwrite it silently.
 
-A v2 project has no `lib/schema.ts` or `drizzle/`. Offer a v9 re-scaffold through update: copy the v9 files, add the pinned dependencies and baseline migrations, migrate, then recreate each workflow through create from its header and purpose. Present the full diff before saving. Keep old ignored JSON results.
+A v2 project has no fixed schema or migrations; offer a v10 re-scaffold through update, preserve ignored results, present the full diff, and migrate after acceptance. A v5 project lacks cancellation. A v6 project combines web research and structured answering incorrectly. A v8 project cannot preserve original provider responses and does not trust the ledger for totals. Offer the v10 recopy and its committed fixed-table migration.
 
-A v5 project lacks the cancel route and the `gtm cancel` command. A v6 project answers Gateway web searches in the same model step as the search, so the evidence never reaches the structured result. A v8 project cannot preserve original vendor responses, contains the web-client-only local runtime regression, and trusts workflow cost estimates instead of its paid-call ledger. Offer the v9 recopy through update: copy the versioned files verbatim and set `gtm.libVersion: 9`. It changes no table, migration, or workflow file.
+A v9 project lets cloud queries reuse the write credential and accepts data-changing CTEs. A v9 project cannot guarantee `tools: "none"` on every local model backend. A v9 cancellation closes the run row before the runtime confirms its in-flight step stopped. A v9 route can lose the SDK run id and reopen the duplicate guard while an orphan is live. A v9 model cache ignores accepted ICP and persona content. A v9 project can persist and return credentials embedded in errors. A v9 ledger starts after the paid call and cannot distinguish reported, fixed, and projected costs. A v9 command allowlist can preapprove real spend and mutation. A v9 approval route duplicates hook schema, uses an internal import, and leaves decided hooks reusable. A v9 local restart can recover and repeat a paid step before the documented zombie procedure runs. A v9 production route accepts starts that do not prove the workspace commit. Offer the v10 recopy through update, show every locally modified managed-file diff, and apply its committed migration with `db:migrate` and `db:verify`.
 
 ## Workflow and table contract
 
-Use a lowercase kebab-case filename and export its camelCase basename. Row-producing workflows have this header:
+Use a lowercase kebab-case filename and export its camelCase basename. Row workflows carry purpose, run location, kind, schedule when applicable, owner, ICP, providers with accepted unit cost, result table, and key meaning in the file header. Export `input`, `MAX_ROWS`, `MAX_SPEND_USD`, `COST_PER_ROW_USD`, the workflow function, and `scheduledInput` for scheduled work. The workflow takes `(arg: Input, meta: WorkflowMeta)` and assigns `arg = input.parse(arg)` immediately after `"use workflow"`; scheduled work sets `arg ??= scheduledInput` first.
 
-```ts
-/**
- * <One sentence stating the workflow purpose.>
- * Runs: on this computer | on Vercel
- * Kind: on-demand | scheduled | triggered
- * Schedule: <UTC cron expression>              // scheduled only
- * Owner: <organization node> | ICP: <ICP name>
- * Providers: <adapter name + endpoint + row cost, or none>
- * Table: <snake_case table> | key: <what key holds>
- */
-```
-
-Export `input`, `MAX_ROWS`, `MAX_SPEND_USD`, `COST_PER_ROW_USD`, the workflow function, and `scheduledInput` for scheduled work. Every workflow accepts `(arg: Input, meta: WorkflowMeta)` and assigns `arg = input.parse(arg)` immediately after `"use workflow"`; this runtime parse is what applies Zod defaults and rejects malformed route input. A scheduled workflow puts `arg ??= scheduledInput` first, then parses it.
-
-Declare each result table in `db/tables/<snake_case>.ts`. Export one `sqliteTable` whose SQL name matches the basename. It has `key: text("key").primaryKey()` and `updatedAt: integer("updated_at").notNull()`. New columns on an existing table are nullable or defaulted. Input schemas that select existing rows include `key`.
-
-The model-facing schema comes from `createInsertSchema(table).pick(...)` inside the step that calls `agent()`. Ask the model only for business columns of type text, integer, or real. Add `key` and `updatedAt` before `upsertRows()`. A save step writes each successful row before the checkpoint can pause the run.
+Declare each result table in `db/tables/<snake_case>.ts` with `key: text("key").primaryKey()` and `updatedAt: integer("updated_at").notNull()`. New columns are nullable or defaulted. `upsertRows()` updates only properties present in each row, so disjoint enrichments do not erase each other. Derive model-facing business fields with `createInsertSchema(table).pick(...)` inside the paid step, then add `key` and `updatedAt` in the save step.
 
 Use this shape and keep business names specific:
+
+```ts
+// db/tables/accounts.ts
+import { integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
+export const accounts = sqliteTable("accounts", {
+  key: text("key").primaryKey(), score: integer("score"), reason: text("reason"),
+  updatedAt: integer("updated_at").notNull(),
+});
+```
 
 ```ts
 import { z } from "zod";
 import { createInsertSchema } from "drizzle-zod";
 import { accounts } from "../db/tables/accounts";
 import { agent } from "../lib/agent";
-import { checkpoint, type WorkflowMeta } from "../lib/approve";
+import type { WorkflowMeta } from "../lib/approve";
 import { upsertRows } from "../lib/db";
-import { updateRun } from "../lib/steps";
-
-export const input = z.object({
-  rows: z.array(z.object({ key: z.string(), domain: z.string() })),
-});
+import { runRows } from "../lib/rows";
+export const input = z.object({ rows: z.array(z.object({ key: z.string(), domain: z.string() })) });
 type Input = z.infer<typeof input>;
-
-export const MAX_ROWS = 100;
-export const MAX_SPEND_USD = 10;
-export const COST_PER_ROW_USD = 0.1;
-
-async function enrichAccount(row: Input["rows"][number], meta: WorkflowMeta) {
+export const MAX_ROWS = 100, MAX_SPEND_USD = 10, COST_PER_ROW_USD = 0.1;
+const acceptedIcp = "<resolved accepted ICP and persona text>";
+async function enrichAccount(row: Input["rows"][number], meta: WorkflowMeta, signal: AbortSignal) {
   "use step";
-  const rowSchema = createInsertSchema(accounts).pick({ score: true, reason: true });
-  try {
-    const result = await agent({
-      prompt: `Score ${row.domain} against the accepted ICP.`,
-      schema: rowSchema,
-      tools: "none",
-      maxUsd: COST_PER_ROW_USD,
-      meta,
-    });
-    return { ok: true, key: row.key, result, costUsd: COST_PER_ROW_USD } as const;
-  } catch (error) {
-    return {
-      ok: false,
-      key: row.key,
-      error: String(error),
-      costUsd: COST_PER_ROW_USD,
-    } as const;
-  }
+  const schema = createInsertSchema(accounts).pick({ score: true, reason: true });
+  const value = await agent({ prompt: `Score ${row.domain}.`, context: acceptedIcp,
+    contextId: "icps/accepted.md", schema, tools: "none", maxUsd: COST_PER_ROW_USD, meta, signal });
+  return { key: row.key, value };
 }
 enrichAccount.maxRetries = 0;
-
 async function saveAccount(row: Record<string, unknown>) {
   "use step";
-  await upsertRows(accounts, [row]);
+  await upsertRows(accounts, [{ ...row, updatedAt: Date.now() }]);
 }
-
 export async function findAccounts(arg: Input, meta: WorkflowMeta) {
   "use workflow";
   arg = input.parse(arg);
-  const projected = arg.rows.length * COST_PER_ROW_USD;
-  if (arg.rows.length > MAX_ROWS || projected > MAX_SPEND_USD) {
-    throw new Error("Accepted workflow limits exceeded");
-  }
-  const completed: string[] = [];
-  const failed: { key: string; error: string }[] = [];
-  let spentUsd = 0;
-  for (const row of arg.rows) {
-    const outcome = await enrichAccount(row, meta);
-    spentUsd += outcome.costUsd;
-    if (outcome.ok) {
-      await saveAccount({ key: outcome.key, ...outcome.result, updatedAt: Date.now() });
-      completed.push(outcome.key);
-    } else failed.push({ key: outcome.key, error: outcome.error });
-    if (completed.length + failed.length === meta.checkpoint) {
-      const decision = await checkpoint(meta, {
-        completed: completed.length,
-        failed: failed.length,
-        spentUsd,
-        projectedRemainingUsd:
-          (arg.rows.length - completed.length - failed.length) * COST_PER_ROW_USD,
-        table: "accounts",
-      });
-      if (!decision.approved) break;
-    }
-  }
-  await updateRun(meta.runKey, {
-    status: "completed",
-    completed: completed.length,
-    failed: failed.length,
-    cost_usd: spentUsd,
-    finished: true,
-  });
-  return { completed, failed };
+  return runRows({ rows: arg.rows, meta, table: { name: "accounts", save: saveAccount },
+    rowStep: enrichAccount, caps: { maxRows: MAX_ROWS, maxSpendUsd: MAX_SPEND_USD,
+      costPerRowUsd: COST_PER_ROW_USD } });
 }
 ```
 
+`runRows()` owns cap-before-spend, ledger-based mid-run caps, per-row isolation, save-before-checkpoint, success/empty/failed counts, held-run stops, remaining keys, terminal status, and cost bookkeeping.
+
 ## Runtime and run identity
 
-`POST /api/run/<path>` starts explicit input. `GET /api/run/<path>` starts scheduled input with `null` as the first workflow argument. The route creates a random `runKey`, hashes stable JSON input, inserts `workflow_runs`, then calls `start()`. A partial unique index on `(path, input_hash)` while `finished_at` is null admits one live matching run.
+`POST /api/run/<path>` starts explicit input. `GET /api/run/<path>` starts `scheduledInput`. The route inserts a random run key and stable input hash before `start()`. A partial unique index on `(path, input_hash)` while `finished_at` is null admits one live matching run.
 
-On a conflict, reconcile once against the SDK and retry one insert. A live row returns 409 with its run key. A row without `run_id` stays live for 120 seconds, then reconciles to `failed` with `start not recorded`. A missing retained SDK run becomes `failed` with `run state expired`.
+The workflow's first library step self-registers the SDK run id and run URL; the route writes the same id best-effort and attaches searchable run-key, workflow, commit, and checkpoint attributes at start. On conflict, reconcile once and retry one insert. A row still missing `run_id` after ten minutes is re-read before it can become `failed` with `start not recorded`.
 
-If a local restart leaves a zombie row in `running` or `waiting`, run `npx workflow cancel <runId>`, then `npm run gtm -- runs get <runKey>`. This is the only unblock procedure.
+Local development sets `WORKFLOW_LOCAL_RECOVER_ACTIVE_RUNS=0`, so restart does not re-enqueue a pending paid step. For a zombie `running`, `waiting`, or `cancelling` row, run `npx workflow cancel <runId>`, then `npm run gtm -- runs get <runKey>`.
 
-`GET /api/runs/<runId|runKey>` reconciles active rows and returns the database row. It includes the SDK result while retained. Approval uses `defineHook`; the bearer-protected approve route calls `resumeHook` directly. A timeout defaults to seven days, records a denial with comment `timeout`, and disposes the hook.
+`GET /api/runs/<runId|runKey>` reconciles active rows and returns the durable row, cost sources, remaining keys, failed step, run URL, and SDK result while retained. Approval and trigger routes are bearer-protected and resume exported typed hooks. Approval rejects stale decisions with `409 approval_not_pending`; denial ends `stopped`, timeout ends `timed_out`, and resolved hooks are disposed.
 
-`POST /api/runs/<runId|runKey>/cancel` is bearer-protected. It reconciles the row, cancels the retained SDK run with an optional `reason`, records `cancelled` with `finished_at`, and returns the row. A finished run answers `409 run_not_active`. A pending approval hook cannot resume after cancellation; the approve route answers `404`. Cancellation takes effect at the next step boundary and does not recall spend already made.
+Cancellation first records non-terminal `cancelling` without `finished_at`, requests SDK cancellation, and signals an in-flight adapter when it honors `AbortSignal`. The live index stays closed until reconciliation sees SDK `cancelled`; saved rows and prior spend remain.
 
-`GET /api/deployment` is bearer-protected and returns the production deployment's `VERCEL_GIT_COMMIT_SHA`. Trusted starts poll it until it matches the accepted workspace commit, then send that commit in `x-gtm-workspace-head`. The POST run route returns `409 deployment_not_ready` when production is not serving that exact commit.
+When `VERCEL_GIT_COMMIT_SHA` exists, production POST starts require `x-gtm-workspace-head`: absence returns `deployment_head_required`, mismatch returns `deployment_not_ready`. The laptop CLI sends clean, pushed `origin/main` automatically for the recorded production URL and refuses dirty or unpushed work.
+
+Scheduled starts persist the UTC `scheduled_for` date under a unique `(path, scheduled_for)` index, so a second delivery returns `already_ran_today` after or during the first run. Recover a missed day with reviewed `scheduledInput` and `--scheduled-for YYYY-MM-DD`; deduplicate downstream delivery by that date. Triggered row handlers skip a key whose `updated_at` is newer than the trigger event.
+
+The platform documentation states that retained run state lasts one day, seven days, or thirty days by plan; the database remains the durable record. A start body is practically limited by the platform's 4.5 MB function request cap. A run is limited to 25,000 events and 10,000 steps, with replay slowing beyond roughly 2,000 events, so split inputs above about 300 rows into child workflows by batch and attach the parent run id as an attribute.
 
 ## Paid calls
 
-Every paid vendor call goes through `provider()` inside an operator-named step. Every model call goes through `agent()`, which uses the same cache and ledger. Each call writes one `enrichment_runs` row. Cache hits cost zero. A backend that reports no model cost records the accepted `maxUsd` projection. Progress and terminal run costs are derived from this ledger; workflow-supplied cost fields are compatibility inputs, not the authoritative total.
+Every paid vendor call goes through `provider()` and every model call through `agent()` inside an operator-named step. Before a cache-miss call, the library writes `pending`; afterward it atomically writes the cache and updates the ledger to `success`, `empty`, or `error`. Terminal reconciliation turns abandoned pending rows into `lost`. Cache hits cost zero, cache parse failures record `error`, and pre-call failures cost zero. `cost_source` distinguishes `reported`, `fixed`, and `projected`; totals include pending and lost fixed cost.
 
-Adapter input is canonical and visible in the cache, so it contains no credential. Paid steps set `maxRetries = 0`. A step may use bounded retries only when it catches every other error and rethrows `RetryableError` solely when the provider confirms the failed attempt was not billed.
-
-See [providers](providers.md) before writing or changing an adapter.
+Adapter inputs are canonical and contain no credential. Pass accepted ICP and persona text to `agent({ context, contextId })`; both affect its cache key. For untrusted row or provider content, `claude` and `api` enforce `tools: "none"`; other local backends must fail before spawn unless the operator explicitly accepts `tools: "host-default"`. Paid steps set `maxRetries = 0`; bounded retries may rethrow only `RetryableError` after confirming the attempt was not billed. See [providers](providers.md).
 
 ## Environment
 
-`TURSO_DATABASE_URL` absent or empty selects `file:./data/gtm.db`; `TURSO_AUTH_TOKEN` empty means absent. A non-file URL selects the Turso dialect. There is no `DATABASE_URL`.
-
-`.env.local` must not exist in `workflows/`. Nitro would load it after `.env` and point local runs at the cloud database while local database commands still used the file. Refuse local start or reuse until it is removed.
-
-`GTM_SANDBOX=1` is the sole sandbox signal. It refuses file URLs, requires `GTM_AGENT_BACKEND=api`, offers no Studio or exposed port, performs no remote Git command, and hands tracked writes to the host approval tool. The sandbox starts no real run: it authors, validates, dry-runs, and queries with a read-only database credential, and accepted migrations apply only inside the host's approval-gated save. Real runs, approvals, and cancellations go through the host's trusted controls against the Vercel deployment. Use the Turso dashboard, `gtm query`, and the trusted status action for sandbox inspection.
+Absent `TURSO_DATABASE_URL` selects `file:./data/gtm.db`; empty tokens mean absent. `.env.local` is forbidden because Nitro could point local runs at the cloud database while local commands use the file. `GTM_SANDBOX=1` requires a remote database and `GTM_AGENT_BACKEND=api`; the sandbox authors, validates, dry-runs, and queries with read-only authority but starts no real run.
 
 ## House rules
 
 | Rule | Required behavior |
 | --- | --- |
-| Business stages define the graph | Give each operator stage one named `"use step"` function and call it directly from the workflow body. |
-| Reachability controls bundles | Workflow-body and module-scope executable code reference only `zod`, `workflow`, `lib/approve`, `lib/steps`, and local step functions. Imports may name drivers, tables, adapters, `agent()`, and `provider()` only when every runtime reference to them stays inside a step body. |
-| Rows have identity | Every result row has a stable `key`; reruns upsert by it. |
-| Tables are declared | Schema changes are table files plus `db:generate` and `db:migrate`, never runtime DDL. |
-| Paid calls use one funnel | Use `provider()` for vendors and `agent()` for models. |
-| Caps precede spend | Reject row or projected-cost excess before the first paid step. |
-| Rows fail independently | Catch row errors inside the row step and continue. |
-| Checkpoints save first | Save the row that reaches the checkpoint before calling `checkpoint()`. |
-| Bookkeeping is explicit | Call terminal `updateRun()` before returning. It aliases the named `recordWorkflowProgressAndStatus` library step. |
-| Scheduled delivery deduplicates | Include the SDK run id and UTC date in delivery payloads. |
+| Business stages define the graph | Give each operator stage one named `"use step"` function. |
+| Reachability controls bundles | Workflow and module-scope executable code use only the allowed workflow helpers and local steps. |
+| Rows have identity | Every result row has a stable `key`; reruns merge by it. |
+| Tables are declared | Schema changes use table files and committed migrations, never runtime DDL. |
+| Paid calls use one funnel | Use `provider()` and `agent()` only inside paid steps with retry policy. |
+| Row bookkeeping is centralized | Use `runRows()`; non-row workflows end with `updateRun()`. |
+| Scheduled delivery deduplicates | Use `scheduled_for`, never the SDK run id, as the delivery key. |
+
+`gtm check` uses the TypeScript compiler API to enforce paid-step retry policy, table keys and timestamps, deterministic workflow bodies, terminal bookkeeping, and allowed module-scope execution. It also validates migrations, managed-file headers and hashes, and warns when installed runtime versions differ from the validated pins.
 
 ## Safety and persistence
 
-Run `npm run gtm -- run <slug> --input <file> --dry-run` before every real run. Gate the real run with rows, stages, projected cost, caps, external writes, and checkpoint position. The first real run of new or changed on-demand work uses `--checkpoint 3` unless the user accepts the full scope. Scheduled runs never checkpoint and rely on caps.
+Run `gtm run --dry-run` before every real run. It imports the workflow without starting it, validates the exported Zod input, counts only parsed `rows`, and checks caps; it does not check table existence or credentials. Gate the real run with rows, stages, projected cost, caps, external writes, and checkpoint position.
 
-Use committed migrations only. Every generated migration includes `drizzle/<sequence>_<name>.sql` and its entry in `drizzle/meta/_journal.json`; schema migrations also include `drizzle/meta/<sequence>_snapshot.json`, while a custom data-only migration may legitimately have no snapshot. Never add migration SQL by hand without registering it in the journal, and never omit the generated snapshot for schema DDL; `gtm check` and the hosted save reject those orphan artifacts. A rename uses `npm run db:generate -- --custom --name <rename-name>` and a hand-written `ALTER TABLE ... RENAME` statement. A drop needs the delete gate and a migration. Nothing runs a migration as a build side effect. A hosted save names every migration file it applies and declares whether any statement drops a table or column; the host refuses an undeclared or unregistered migration and verifies each accepted SQL hash exists in `__drizzle_migrations` before committing.
+Use committed migrations only. `gtm check` rejects orphan artifacts and flags `DELETE`, `UPDATE`, `RENAME`, `DROP`, and `CREATE TRIGGER` for explicit destructive review. Use expand/contract for renames: add a compatible column, backfill in a separately reviewed migration, switch code, and drop only after the old deployment is gone. Show full SQL for anything beyond additive `CREATE TABLE` or `ADD COLUMN`, apply with `db:migrate`, and run `db:verify`; nothing migrates as a build side effect.
 
-Stop a live run with `npm run gtm -- cancel <runId|runKey>` or the trusted cancel action. Report that cancellation stops at the next step boundary, keeps rows already saved, and does not refund spend.
-
-Secrets stay out of prompts, tracked files, step input and output, ledgers, comments, and command output. Values move through ignored environment files or shell input. Treat hook tokens and per-run webhook URLs as unsafe to share even though the approve route also requires the bearer.
+Secrets stay out of prompts, tracked files, step input and output, ledgers, comments, and command output; the library defensively redacts error paths. If a user pastes a credential into the conversation, treat it as compromised: help rotate it and store the replacement through the environment. Approval and trigger tokens only name a pending stage; the route bearer authorizes the action. A public per-run webhook URL remains a capability and must not be shared.

--- a/skills/gtm-workflow/references/conversation.md
+++ b/skills/gtm-workflow/references/conversation.md
@@ -30,7 +30,7 @@ Use one save gate for each coherent batch of tracked changes. After acceptance, 
 Reply with a number, or type your answer.
 ```
 
-Keep source, schemas, configuration bodies, diffs, and complete files out of the default proposal. Name generated migration files after acceptance. Show requested technical detail without weakening a gate.
+Keep source, schemas, configuration bodies, diffs, and complete files out of the default proposal, except that any migration beyond additive `CREATE TABLE` or `ADD COLUMN` must show its full SQL. Name generated migration files after acceptance. Show requested technical detail without weakening a gate.
 
 When any affected workflow says `Runs: on Vercel`, the proposal must say that acceptance commits the batch to `main` and starts a production Vercel deployment. Report the immediate result as `deploying`; call it `live` only after the production deployment endpoint reports the exact returned commit SHA.
 
@@ -44,12 +44,14 @@ Add a short caption with the trigger, inputs or changes, saved result, and parti
 
 ## Outcome reports
 
-Lead completion with the business result and `<n> completed, <m> failed`. Follow with rows written, table name, cache hits, vendor cost, model cost, external systems changed, and delivery state. Say when a model cost is the accepted projection because the backend did not report billing.
+Lead completion with the business result and `<n> completed, <m> failed`. Follow with rows written, table, cache hits, vendor and model cost, `reported | fixed | projected` cost sources, external systems changed, and delivery state. A projected cost is the accepted ceiling because the backend did not report billing.
 
 At a checkpoint, report `<n> rows done, <m> failed, $<x> spent, $<y> projected for the remaining rows`, the table inspection command, and the exact approval command. Ask for approval before resuming the same run.
 
-For a cancelled run, say `<workflow> was cancelled as <runKey>` with rows saved, spend so far, and that no further spend occurs after the current step.
+Use `completed` only when all accepted work ended normally. Say `stopped` for operator denial, provider authentication or quota hold, or a spend-cap stop; include `stop_reason` and `remaining_keys`. Say `timed out` for an expired approval and `failed at <failed_step>` when step identity is available.
+
+While cancellation is pending, say `<workflow> is cancelling as <runKey>` and that the duplicate guard remains closed. At terminal state, say `<workflow> was cancelled as <runKey>` with rows saved and ledger spend; an already-issued request may have completed before the runtime suspension point.
 
 For a duplicate run, say `<workflow> is already running as <runKey>`. Offer inspection first. If the operator wants to abandon a zombie run, give the one recovery sequence: cancel the SDK run, then reconcile with `gtm runs get`.
 
-Keep ports, process controls, SDK run IDs, project identifiers, environment names, branch names, token counts, and telemetry in internal diagnostics unless the user requests them or they safely disambiguate an action. Keep production bearers, OIDC tokens, hook tokens, and per-run webhook URLs out of messages and tool results. Run keys may appear when needed for inspection or duplicate recovery. Describe clean persistence as `saved to history`.
+Keep ports, process controls, SDK run IDs, project identifiers, environment names, branch names, token counts, and telemetry in internal diagnostics unless requested or needed to disambiguate an action. Keep production bearers, OIDC tokens, and public per-run webhook URLs out of messages and tool results. Approval and trigger tokens merely name the pending stage; trusted controls may still resolve them internally to keep the operator interaction concise. Run keys may appear for inspection or duplicate recovery. Describe clean persistence as `saved to history`.

--- a/skills/gtm-workflow/references/deploy.md
+++ b/skills/gtm-workflow/references/deploy.md
@@ -11,13 +11,13 @@ Offer a saved-but-not-deployed option only by keeping the draft outside the repo
 ## Before the commit
 
 1. Run `npm run gtm -- check` and the accepted production input through `gtm run --dry-run`.
-2. Generate committed migrations only after acceptance. Inspect the SQL and require its matching `drizzle/meta/_journal.json` entry in the same tracked batch; schema DDL also requires its numbered snapshot, while a custom data-only migration may have none.
+2. Generate committed migrations only after acceptance. Inspect the SQL and require its journal entry plus numbered snapshot when schema DDL needs one. Show the full SQL for anything beyond additive `CREATE TABLE` or `ADD COLUMN`; declare `DELETE`, `UPDATE`, `RENAME`, `DROP`, and `CREATE TRIGGER` destructive. Use expand/contract instead of an in-place rename.
 3. Apply new committed migrations to the workspace Turso database inside the approval-gated save operation, then verify every accepted SQL SHA-256 hash exists in `__drizzle_migrations` before creating the Git commit. A successful command without the ledger entries is a failed save. Migrations must be backward-compatible because an applied migration can outlive a failed commit or deployment. Nothing runs migration as a build side effect.
 4. Require the connected workflow project to expose Vercel system environment variables so `VERCEL_GIT_COMMIT_SHA` is available at runtime.
 
 In a sandbox, submit the accepted tracked batch through `apply_gtm_workspace_changes`. The request names every migration file it carries, includes the generated journal plus any schema snapshot, and declares whether any statement drops a table or column. The tool stages the accepted workflow tree, applies its new migrations through a write credential that exists only for that step, verifies their hashes in the ledger, then atomically commits to `main`. It never receives a Vercel token and never opens `api.vercel.com`.
 
-On a laptop, obtain a current database URL and write token directly from Turso and place the non-empty pair in ignored `.env.turso`. Sensitive Vercel variables are not returned by `vercel env pull`. Run `npm run db:migrate:cloud`; its credential preflight, migration exit status, and ledger verification must all pass before committing and pushing the accepted batch to `main`.
+On a laptop, place these three non-empty values in ignored `.env.turso`: `TURSO_DATABASE_URL`, the write-only `TURSO_AUTH_TOKEN` used by `db:migrate:cloud`, and `TURSO_READ_ONLY_AUTH_TOKEN` used by `gtm query --cloud` and `db:studio:cloud`. Neither inspection command may fall back to the write token. Run the cloud migration; its credential preflight, exit status, and ledger verification must all pass before committing and pushing the accepted batch to `main`.
 
 ## Git-connected project setup
 
@@ -42,7 +42,7 @@ After the save tool returns the new commit SHA, production is deploying, not yet
 1. repeat the zero-spend dry run against that exact committed checkout;
 2. poll the bearer-protected `GET /api/deployment` route with Eve's short-lived OIDC identity until it returns that exact SHA;
 3. time out without starting when the SHA never becomes live; and
-4. send the same SHA in `x-gtm-workspace-head` on `POST /api/run/<workflow>` so the runtime rechecks it atomically.
+4. send the same SHA in `x-gtm-workspace-head` on `POST /api/run/<workflow>` so the runtime rechecks it atomically; production refuses a missing header as well as a mismatch.
 
 The run route returns `409 deployment_not_ready` if production changed between the poll and the start. Never fall back to an older deployment or silently run a different commit.
 
@@ -51,13 +51,15 @@ The run route returns `409 deployment_not_ready` if production changed between t
 1. Start the first real run with a checkpoint after three rows through the trusted start action, or use the CLI against the production URL after its exact commit is live.
 2. Query the first rows and inspect the run.
 3. Ask for checkpoint approval and resume the same run. The trusted control resolves the hook token internally and never returns it.
-4. Stop a live run with the trusted cancel action or `npm run gtm -- cancel <runKey>`; it is approval-gated and reports the run as `cancelled`.
+4. Stop a live run with the trusted cancel action or `npm run gtm -- cancel <runKey> --wait`; it is approval-gated, polls through `cancelling`, and reports terminal `cancelled`.
 5. Require a terminal `workflow_runs` row, expected business rows, and a visible run in Vercel Observability.
-6. For a scheduled workflow, invoke its GET route once with `CRON_SECRET`; a second matching live GET must return 409.
-7. For a webhook workflow, require `runs get` to show its per-run URL, POST one fixture payload, and require completion.
+6. For a scheduled workflow, invoke its GET route once with `CRON_SECRET`; a second GET for the same UTC date must return `already_ran_today`, even after completion. Verify a missed-date catch-up with reviewed input and `--scheduled-for`.
+7. For a triggered workflow, require `runs get` to show a pending trigger, POST one fixture payload to the bearer-protected trigger route, and require completion. Use a public webhook only when the caller cannot send the bearer, and validate its payload.
 
 ## Live state
 
 `Deploying` means the accepted `main` commit exists but the production deployment endpoint does not yet report that SHA. `Live` means the exact SHA is in production, its migration has applied, and verification reached the expected database and workflow state. A draft outside Git is neither saved nor live.
 
-On Vercel Hobby, cron may fire once daily within its hour and may double-fire. The live-run guard covers overlap. Delivery payloads include the SDK run id and UTC date for receiver deduplication.
+The platform documentation sets the lowest-plan function cap at 300 seconds; `agent()` defaults below it at 240 seconds. Retained execution is temporary, while `workflow_runs`, the paid ledger, and business tables are the durable record; see the contract for plan retention, request-body, event, step, and child-workflow batching limits.
+
+Cron may double-fire or miss. The `scheduled_for` unique key covers same-day overlap and completed duplicates; delivery payloads use that UTC date, not the SDK run id, for receiver deduplication.

--- a/skills/gtm-workflow/references/flows.md
+++ b/skills/gtm-workflow/references/flows.md
@@ -44,16 +44,16 @@ Bootstrap during the first create and keep the draft outside the repository unti
 ## Create
 
 1. Resolve workspace, owner, and kind. Read the owner's relevant ICP and persona files.
-2. Compare the headered template version before editing an existing project. Offer a v9 recopy when needed.
-3. Resolve where it runs. For on-demand work, recommend this computer. For scheduled or webhook work, recommend Vercel. In a sandbox, recommend Vercel for every workflow because the sandbox never starts a real run. Explain that local scheduled work runs only when invoked and model calls on Vercel use the user's budgeted Gateway key.
+2. Run `gtm check` before editing an existing project. Offer a v10 recopy when headers or content hashes differ; show the diff for every locally modified managed file first.
+3. Resolve where it runs. For on-demand work, recommend this computer. For scheduled or triggered work, recommend Vercel. In a sandbox, recommend Vercel for every workflow because the sandbox never starts a real run. Explain that local scheduled work runs only when invoked and hosted model calls use the user's budgeted key.
 4. Resolve the purpose, explicit input shape, stable row key, result columns, paid stages, adapter docs, caps, timing, approval stages, checkpoint, and external writes.
 5. When the workflow needs a provider, read [providers](providers.md), write its adapter against the user's own credential, and test it against fixtures. The skill ships no adapter catalog.
-6. Declare the result table and derive the model-facing business schema with drizzle-zod inside the agent step. Add `key` and `updatedAt` only when saving.
-7. Write the workflow from the contract skeleton. Add `scheduledInput` and a matching `vercel.json` entry for scheduled work. Offer `createWebhook()` only for a triggered workflow that runs on Vercel.
-8. Check basename-to-export, row input, reachability, caps before spend, `maxRetries = 0`, save before checkpoint, and terminal `updateRun`.
-9. Run `npm run gtm -- check`. Run `gtm run --dry-run` against the accepted input. A fresh table is not required for this dry run.
+6. Declare the result table, derive the model-facing business schema inside the agent step, and load the owner's accepted ICP and persona text into `context` with stable file paths in `contextId`. Add `key` and `updatedAt` only when saving.
+7. Write row work with `runRows()`. Add `scheduledInput` and matching cron entry for scheduled work. For triggered work, prefer `waitForTrigger()` plus the bearer-protected trigger route; use a public webhook only when the caller cannot send a bearer, and validate its payload in the workflow.
+8. Run `npm run gtm -- check`; it enforces export, input, compiler-level workflow, paid-step retry, table, bookkeeping, migration, version, and content-hash rules.
+9. Run `gtm run --dry-run` against the accepted input. It validates the Zod schema and caps without spend; a fresh table and working credentials are not required.
 10. Present one save proposal containing behavior, table and key, stages, dry-run output, caps, checkpoint, external writes, migration files to be generated, deployment state, and affected file groups.
-11. On acceptance, copy the draft into the workspace, run `npm ci`, then `db:generate`. Inspect the generated SQL and confirm the same batch contains its `_journal.json` update plus the numbered snapshot required for schema DDL. For a Vercel workflow, the approval-gated save operation applies the accepted migration, verifies its SQL hash in `__drizzle_migrations`, and only then creates its one atomic `main` commit; that commit starts production deployment. For local work, run `db:migrate` and verify the ledger hash before saving.
+11. On acceptance, copy the draft into the workspace, run `npm ci`, then `db:generate`. Inspect the generated SQL and its journal and snapshot artifacts. Show full SQL for any non-additive migration. Apply accepted migrations, run `db:verify`, and only then save; a Vercel workflow's one atomic `main` commit starts production deployment.
 12. If the header says `Runs: on Vercel`, follow [deploy](deploy.md) and report the commit as deploying. Otherwise enter the run gate. The first real run defaults to a checkpoint after three rows.
 
 Cancellation before step 11 writes no tracked bytes and no migration.
@@ -61,12 +61,12 @@ Cancellation before step 11 writes no tracked bytes and no migration.
 ## Update
 
 1. Resolve the workflow and inspect its header, table, adapter, migrations, schedule, approvals, and deployment state.
-2. Compare every headered file with v9. Include any accepted recopy in the proposal.
+2. Compare every managed file with v10 by header and recorded hash. Show locally modified diffs and include any accepted recopy in the proposal.
 3. Agree the business change. A run-location switch is an update to the same workflow.
-4. Change only the workflow, table, adapter, environment names, cron entry, or deployment metadata required by the request.
-5. New columns are nullable or defaulted. For a rename, plan a custom migration and hand-write `ALTER TABLE ... RENAME`. Keep schedule headers, `scheduledInput`, and cron entries aligned.
+4. Change only the workflow, table, adapter, accepted ICP/persona context, environment names, cron entry, or deployment metadata required by the request. Reload context text so its changed content invalidates the model cache.
+5. New columns are nullable or defaulted. Use expand/contract for a rename: add, backfill, switch code, then drop after the old deployment is gone. Keep schedule headers, `scheduledInput`, and cron entries aligned.
 6. Run `gtm check` and the dry run before the save proposal. Do not generate a migration yet.
-7. Present one proposal. On acceptance, run `db:generate`, inspect the SQL, and save the SQL and journal together, including the numbered snapshot for schema DDL. The approval-gated save operation applies Vercel-workflow migrations and verifies their ledger hashes before its `main` commit; local work runs `db:migrate` and verifies the ledger before saving. If behavior changed, enter the checkpointed run gate.
+7. Present one proposal. On acceptance, run `db:generate`, inspect the SQL, save its registered artifacts together, apply the migration, and run `db:verify`. The approval-gated hosted save verifies hashes before its `main` commit. If behavior changed, enter the checkpointed run gate.
 8. A `main` commit deploys when the accepted header says `Runs: on Vercel`; wait for that exact SHA before a real run.
 
 ## Inspect
@@ -110,7 +110,7 @@ For a run, use `npm run gtm -- runs get <runId|runKey>` and `gtm query` for its 
 npm run gtm -- run <slug> --input <file> --dry-run
 ```
 
-5. Show rows, stages, projected cost, caps, external writes, and checkpoint position. State that dry run calls no provider or model.
+5. Show rows, stages, projected cost, caps, external writes, and checkpoint position. State that dry run calls no provider or model, does not check table existence, and does not test credentials.
 6. Ask:
 
 ```text
@@ -128,10 +128,12 @@ Reply with a number, or type your answer.
 Omit option 1 for scheduled work. If the user chooses full scope, start without a checkpoint.
 
 7. Start with `npm run gtm -- run <slug> --input <file> --checkpoint 3 --wait`, or use the trusted workflow control's approved start action for Vercel. The action returns on start; inspect the run until it reaches a terminal state or a wait.
-8. At a checkpoint or approval, report the saved rows, failures, spend, remaining projection, table, and exact inspection command. Ask the user to approve, deny, or comment. Continue the same run with `npm run gtm -- approve <token> --yes --wait`, or the trusted workflow control's approved decision action, only after their answer. The trusted control resolves the hook token internally and never returns it to the agent or Slack.
+8. At a checkpoint or approval, report saved rows, failures, ledger spend and cost sources, remaining projection, table, and exact inspection command. Ask the user to approve, deny, or comment. Continue the same run with `npm run gtm -- approve <token> --yes --wait`, or the trusted workflow control's approved decision action, only after their answer. The token names the pending stage; the bearer authorizes it.
 9. If start returns `run_in_progress`, report the existing run key and do not retry. Inspect it. Use the cancel and reconcile recovery only when the operator chooses to abandon it.
-10. To stop a live run, use `npm run gtm -- cancel <runKey>` or the trusted control's approval-gated cancel action. Report that cancellation takes effect at the next step boundary, keeps saved rows, and does not refund spend.
-11. Report completed, failed, rows written, cache hits, vendor cost, model cost, and external changes. Costs for backends without reported billing are projections.
+10. To stop a live run, use `npm run gtm -- cancel <runKey> --wait` or the trusted approval-gated cancel action. Poll through `cancelling`; the duplicate guard stays closed until terminal `cancelled`. Saved rows and prior spend remain.
+11. Report the honest terminal state: `completed`, `stopped`, `timed_out`, `failed`, or `cancelled`; include stop reason, remaining keys, failed step, rows written, cache hits, cost-source breakdown, and external changes.
+
+For a missed scheduled day, write `scheduledInput` to an ignored file, dry-run it, then use `--scheduled-for <YYYY-MM-DD>` through the same run gate. A second start for that workflow and date returns `already_ran_today`.
 
 Row selection composes two commands:
 
@@ -149,7 +151,7 @@ When `GTM_SANDBOX=1`:
 1. Build a new scaffold under `$HOME/.gtm-scratch/<repo>/workflows/`. Reuse it for the session.
 2. Require `TURSO_DATABASE_URL` and `GTM_AGENT_BACKEND=api`. The runtime refuses a file database and CLI backend.
 3. Submit tracked bytes through the host approval tool. Run no `git push`, `git fetch`, `git remote`, or other remote Git command.
-4. A save containing `Runs: on Vercel` changes applies accepted migrations and commits once to `main`, which triggers the connected Vercel project. Name every migration file in the save and declare a destructive statement explicitly. Use trusted controls for read-only preview and status, and approval-gated start, approval, and cancel actions. Start waits for the exact committed HEAD. Keep the production run bearer, OIDC tokens, and hook tokens in the host runtime; there is no deploy token.
+4. A save containing `Runs: on Vercel` changes applies accepted migrations and commits once to `main`, which triggers the connected Vercel project. Name every migration and include full SQL for non-additive statements. Use trusted controls for read-only preview and status, and approval-gated start, approval, and cancel actions. Start waits for the exact committed HEAD. Keep the production run bearer and OIDC tokens in the host runtime; there is no deploy token.
 5. Use no Studio and expose no port. Relay `gtm query --format markdown`, `gtm runs get`, `workflow inspect run`, and `workflow inspect hooks` output.
 6. Start no real run in the sandbox. `Runs: on this computer` is a keyboard location; in the sandbox, recommend and deploy `Runs: on Vercel`. The sandbox database credential is read-only, so rows change only through hosted runs and accepted migrations.
 
@@ -158,15 +160,16 @@ When `GTM_SANDBOX=1`:
 | Failure | Required response |
 | --- | --- |
 | `.env.local` exists | Stop local server start or reuse. Name the file and explain that it would select the cloud database. |
-| No local model backend | Ask for a supported CLI backend or a budgeted Gateway key. |
+| No injection-safe local model backend | For untrusted input, use a backend that enforces `tools: "none"`; accept `tools: "host-default"` only for trusted input after explicit operator review. |
 | Sandbox CLI backend selected | Set `GTM_AGENT_BACKEND=api` and provide the Gateway credential through the host. |
 | Sandbox file URL selected | Supply the workspace Turso URL and token through the host. |
 | Duplicate live run | Inspect the returned run key. Do not retry. |
-| Zombie `running` or `waiting` row | Run `npx workflow cancel <runId>`, then `npm run gtm -- runs get <runKey>`. |
+| Zombie `running`, `waiting`, or `cancelling` row | Keep `WORKFLOW_LOCAL_RECOVER_ACTIVE_RUNS=0`; run `npx workflow cancel <runId>`, then `npm run gtm -- runs get <runKey>`. |
 | Runaway or stuck hosted run | Run `npm run gtm -- cancel <runKey>` or the trusted cancel action, then inspect with `runs get` or the status action. |
-| Hook no longer pending | Inspect the run. A timed-out or completed hook cannot resume. |
+| Hook no longer pending | Inspect the run. A denied, timed-out, cancelled, completed, or already-resolved hook cannot resume. |
 | No Vercel model backend | Add a budgeted Gateway key, then deploy again. |
-| Provider or model allowance exhausted | Change the budget or backend, then run only the explicitly selected rows. |
+| Provider authentication or quota hold | Fix credentials or budget, inspect `remaining_keys`, then create a newly approved input containing only those keys. |
+| Run state expired | The retained SDK state exceeded the plan window; use `workflow_runs`, the ledger, and result tables as the durable record. |
 | Table missing at runtime | Do not retry the workflow. Compare its runtime SQL table name with the declaration and generated migration, repair any orphan migration with `db:generate`, run `db:migrate`, then verify both the table and the migration hash in `__drizzle_migrations`. Enter the run gate again only after those checks pass. |
 | Local migration is busy | Stop the owned Nitro process and retry `db:migrate` once. |
 | Graph or lib change not visible | Restart the owned Nitro process through `open.md`. |

--- a/skills/gtm-workflow/references/open.md
+++ b/skills/gtm-workflow/references/open.md
@@ -34,7 +34,7 @@ When the user asks for private remote access, hand the running Nitro origin to t
 2. If either value is absent, report that the project is not deployed and stop. When the user named a workflow, also require its header to say `Runs: on Vercel`; otherwise report that the workflow is not deployed and stop.
 3. Run `./node_modules/.bin/workflow inspect runs --backend vercel --project <project> --team <team> --url` with both recorded values.
 4. Open the printed URL. If it cannot be opened, say `In the Vercel project, open Observability, then Workflows.`
-5. For table inspection, use the Turso dashboard or run `npm run db:studio:cloud` on the user's computer.
+5. For table inspection, use the Turso dashboard or run `npm run db:studio:cloud` on the user's computer. Ignored `.env.turso` contains `TURSO_DATABASE_URL`, write-only `TURSO_AUTH_TOKEN` for migrations, and `TURSO_READ_ONLY_AUTH_TOKEN` for Studio and `gtm query --cloud`; inspection refuses to reuse the write token.
 
 ## Sandbox inspection
 
@@ -51,7 +51,7 @@ npm run gtm -- query --sql "select run_key, status, completed, failed, cost_usd 
 - Record the PID, command, working directory, and purpose for every server this session starts.
 - Stop and confirm exit only for server PIDs this session started. Leave matching servers from other sessions and unrelated processes running.
 - On cancellation, stop only a server this session started.
-- CLI-agent subprocesses belong to Nitro's process group and end on their own or at `timeoutMs`. Cancelling a run with `./node_modules/.bin/workflow cancel` takes effect at the next step boundary.
+- CLI-agent subprocesses belong to Nitro's process group and end on their own or at `timeoutMs`. `npm run gtm -- cancel <runKey> --wait` polls `cancelling` until the runtime confirms terminal cancellation; an adapter using the library signal may stop sooner.
 
 ## Empty workflow recovery
 

--- a/skills/gtm-workflow/references/providers.md
+++ b/skills/gtm-workflow/references/providers.md
@@ -37,9 +37,11 @@ const result = await provider({
 });
 ```
 
-The call returns a validated `value`, the cost attributed to this run, and `cache_hit`, `success`, or `empty`. A cache miss stores the adapter payload in `enrichment_cache.raw` before schema parsing and keeps the parsed copy in `value`. Cache hits parse `raw` so added schema fields can use the original response. Rows written before v4 have no `raw`, so they fall back to `value`. A cache hit writes a ledger row with zero cost. A miss writes the cache and one ledger row. A throw writes one `error` row and rethrows.
+The call returns a validated `value`, attributed cost and source, and `cache_hit`, `success`, or `empty`. A miss writes a `pending` ledger row before the request, then atomically writes the cache and final ledger state. Cache hits parse preserved `raw`, fall back to `value` for older rows, and cost zero; a cache-parse failure records `error`. Terminal reconciliation marks unresolved pending calls `lost` at the accepted fixed cost.
 
-When the service reports actual cost, return `{ value, costUsd }` from the adapter call. When debugging or future normalization needs the original vendor response, return `{ raw, value, costUsd }` and supply `parseRaw` to rebuild `value` from `raw` on cache hits. Otherwise `provider()` records the accepted fixed cost. `agent()` records reported model cost when available and the accepted `maxUsd` projection otherwise. Outcome reports distinguish projected model cost.
+When the service reports actual cost, return `{ value, costUsd }`. Return `{ raw, value, costUsd }` and supply `parseRaw` when later schema expansion needs the original response. Otherwise `provider()` records fixed cost; `agent()` records reported model cost when available and projected `maxUsd` otherwise. Pre-call input or spawn failures use `ProviderPreCallError` and cost zero.
+
+Throw short, actionable messages without request URLs or credentials. The library still strips query strings, bearer values, sensitive assignments, matching secret environment values, and text beyond its response limit before errors reach ledgers, run rows, routes, or CLI output.
 
 ## Slack Block Kit links
 
@@ -54,10 +56,11 @@ Classify errors by what the workflow should do:
 | Condition | Behavior |
 | --- | --- |
 | Invalid input or permanent rejection | Throw a normal error. The row fails and continues. |
-| Authentication or account limit | Throw a normal error with a short actionable message. Do not retry rows automatically. |
+| Authentication failure | Throw `ProviderAuthError`. `runRows()` stops with `provider_auth` and records remaining keys. |
+| Quota, billing, or account limit | Throw `ProviderQuotaError`. `runRows()` stops with `provider_quota` and records remaining keys. |
 | Charged request with invalid output | Throw a normal error. `maxRetries = 0` prevents rebilling. |
-| Confirmed unbilled transient failure | Throw `RetryableError`. The enclosing step may use a small bounded retry count. |
-| Asynchronous job accepted | Poll inside the paid step with a bounded timeout, or use a workflow webhook when the service can call back. |
+| Confirmed unbilled transient failure | Import `RetryableError` from `"workflow"` and throw it. A bare throw uses the runtime's default retry policy unless the step sets `maxRetries = 0`; a bounded retry exception must catch every other error. |
+| Asynchronous job accepted | Poll inside the paid step with a bounded timeout, or use a typed hook behind the authorized trigger route. Use a public webhook only when the caller cannot send a bearer. |
 
 Never infer that a timeout was unbilled. Default to no retry.
 

--- a/skills/gtm-workflow/scripts/command-permission.mjs
+++ b/skills/gtm-workflow/scripts/command-permission.mjs
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+import { readFile } from "node:fs/promises";
+
+const direct = process.argv[2] === "--classify" ? process.argv.slice(3).join(" ") : null;
+const payload = direct === null ? JSON.parse((await readFile(0, "utf8")) || "{}") : null;
+const command = direct ?? payload?.tool_input?.command ?? "";
+const decision = classify(command);
+
+if (direct !== null) {
+  process.stdout.write(`${JSON.stringify({ decision })}\n`);
+} else {
+  process.stdout.write(
+    `${JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: decision,
+        permissionDecisionReason:
+          decision === "allow"
+            ? "The command is a read-only GTM workflow inspection or dry run."
+            : "The command may spend, mutate, deploy, or could not be classified safely.",
+      },
+    })}\n`,
+  );
+}
+
+export function classify(command) {
+  if (!command.trim() || /[$`;\\&<>|\r\n]/.test(command)) return "ask";
+  const argv = split(command);
+  if (!argv) return "ask";
+
+  if (starts(argv, ["npm", "run", "gtm", "--"])) {
+    const args = argv.slice(4);
+    if (args[0] === "check" || args[0] === "query") return "allow";
+    if (args[0] === "runs" && args[1] === "get") return "allow";
+    if (args[0] === "run" && args.includes("--dry-run")) return "allow";
+    return "ask";
+  }
+  if (
+    starts(argv, ["npm", "run", "db:generate"]) ||
+    starts(argv, ["npm", "run", "db:studio"]) ||
+    starts(argv, ["npm", "run", "db:studio:cloud"]) ||
+    starts(argv, ["npm", "run", "db:verify"])
+  ) {
+    return "allow";
+  }
+  if (
+    starts(argv, ["npx", "workflow", "inspect"]) ||
+    starts(argv, ["npx", "workflow", "validate"])
+  ) {
+    return "allow";
+  }
+  return "ask";
+}
+
+function starts(argv, prefix) {
+  return prefix.every((value, index) => argv[index] === value);
+}
+
+function split(command) {
+  const argv = [];
+  let value = "";
+  let quote = null;
+  for (const character of command.trim()) {
+    if (quote) {
+      if (character === quote) quote = null;
+      else value += character;
+      continue;
+    }
+    if (character === '"' || character === "'") {
+      quote = character;
+      continue;
+    }
+    if (/\s/.test(character)) {
+      if (value) {
+        argv.push(value);
+        value = "";
+      }
+      continue;
+    }
+    value += character;
+  }
+  if (quote) return null;
+  if (value) argv.push(value);
+  return argv;
+}

--- a/skills/gtm-workflow/templates/.env.example
+++ b/skills/gtm-workflow/templates/.env.example
@@ -1,7 +1,19 @@
 # Set by the Vercel Marketplace on Vercel. Leave empty for local runs; the local database is data/gtm.db.
 TURSO_DATABASE_URL=
+# Production write token. Only db:migrate:cloud uses it.
 TURSO_AUTH_TOKEN=
+# Read-only token for query --cloud and db:studio:cloud.
+TURSO_READ_ONLY_AUTH_TOKEN=
+# Shared bearer for starts, status, approvals, triggers, and cancellation.
 GTM_RUN_SECRET=
+# Set to the run bearer for scheduled GET delivery.
+CRON_SECRET=
+# Set to 1 only in the hosted authoring sandbox.
+GTM_SANDBOX=
+# Override the local or recorded production origin for CLI requests.
+GTM_BASE_URL=
+# Keep local active-run recovery off so restart cannot repeat a paid step.
+WORKFLOW_LOCAL_RECOVER_ACTIVE_RUNS=
 GTM_AGENT_BACKEND=
 GTM_AGENT_MODEL=
 AI_GATEWAY_API_KEY=

--- a/skills/gtm-workflow/templates/drizzle.config.ts
+++ b/skills/gtm-workflow/templates/drizzle.config.ts
@@ -1,4 +1,4 @@
-// gtm-lib v9
+// gtm-lib v10
 import { defineConfig } from "drizzle-kit";
 import { getDatabaseConfig } from "./lib/db-url";
 

--- a/skills/gtm-workflow/templates/drizzle/0002_abandoned_quentin_quire.sql
+++ b/skills/gtm-workflow/templates/drizzle/0002_abandoned_quentin_quire.sql
@@ -1,0 +1,10 @@
+ALTER TABLE `enrichment_runs` ADD `cost_source` text DEFAULT 'fixed' NOT NULL;--> statement-breakpoint
+ALTER TABLE `enrichment_runs` ADD `error_kind` text;--> statement-breakpoint
+ALTER TABLE `workflow_runs` ADD `stop_reason` text;--> statement-breakpoint
+ALTER TABLE `workflow_runs` ADD `remaining_keys` text;--> statement-breakpoint
+ALTER TABLE `workflow_runs` ADD `failed_step` text;--> statement-breakpoint
+ALTER TABLE `workflow_runs` ADD `run_url` text;--> statement-breakpoint
+ALTER TABLE `workflow_runs` ADD `trigger_token` text;--> statement-breakpoint
+ALTER TABLE `workflow_runs` ADD `scheduled_for` text;--> statement-breakpoint
+ALTER TABLE `workflow_runs` ADD `cancel_requested_at` integer;--> statement-breakpoint
+CREATE UNIQUE INDEX `workflow_runs_scheduled_idx` ON `workflow_runs` (`path`,`scheduled_for`) WHERE scheduled_for IS NOT NULL;

--- a/skills/gtm-workflow/templates/drizzle/meta/0002_snapshot.json
+++ b/skills/gtm-workflow/templates/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,400 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "fc4de84d-5480-485f-9a61-d4c5590c9895",
+  "prevId": "dcadf9ef-0364-444f-8f72-fdb0368442e0",
+  "tables": {
+    "enrichment_cache": {
+      "name": "enrichment_cache",
+      "columns": {
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inputs_hash": {
+          "name": "inputs_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inputs": {
+          "name": "inputs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "raw": {
+          "name": "raw",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "enrichment_cache_provider_endpoint_inputs_hash_pk": {
+          "columns": [
+            "provider",
+            "endpoint",
+            "inputs_hash"
+          ],
+          "name": "enrichment_cache_provider_endpoint_inputs_hash_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "enrichment_runs": {
+      "name": "enrichment_runs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "run_key": {
+          "name": "run_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workflow": {
+          "name": "workflow",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inputs_hash": {
+          "name": "inputs_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_source": {
+          "name": "cost_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'fixed'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_kind": {
+          "name": "error_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "enrichment_runs_run_key_idx": {
+          "name": "enrichment_runs_run_key_idx",
+          "columns": [
+            "run_key"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "workflow_runs": {
+      "name": "workflow_runs",
+      "columns": {
+        "run_key": {
+          "name": "run_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "workflow": {
+          "name": "workflow",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input": {
+          "name": "input",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input_hash": {
+          "name": "input_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stop_reason": {
+          "name": "stop_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "remaining_keys": {
+          "name": "remaining_keys",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "failed_step": {
+          "name": "failed_step",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "run_url": {
+          "name": "run_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed": {
+          "name": "completed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "failed": {
+          "name": "failed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "checkpoint": {
+          "name": "checkpoint",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "webhook_url": {
+          "name": "webhook_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trigger_token": {
+          "name": "trigger_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "approval": {
+          "name": "approval",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scheduled_for": {
+          "name": "scheduled_for",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cancel_requested_at": {
+          "name": "cancel_requested_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "workflow_runs_run_id_unique": {
+          "name": "workflow_runs_run_id_unique",
+          "columns": [
+            "run_id"
+          ],
+          "isUnique": true
+        },
+        "workflow_runs_live_idx": {
+          "name": "workflow_runs_live_idx",
+          "columns": [
+            "path",
+            "input_hash"
+          ],
+          "isUnique": true,
+          "where": "finished_at IS NULL"
+        },
+        "workflow_runs_scheduled_idx": {
+          "name": "workflow_runs_scheduled_idx",
+          "columns": [
+            "path",
+            "scheduled_for"
+          ],
+          "isUnique": true,
+          "where": "scheduled_for IS NOT NULL"
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/skills/gtm-workflow/templates/drizzle/meta/_journal.json
+++ b/skills/gtm-workflow/templates/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1787777723887,
       "tag": "0001_wise_mac_gargan",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "6",
+      "when": 1787907952921,
+      "tag": "0002_abandoned_quentin_quire",
+      "breakpoints": true
     }
   ]
 }

--- a/skills/gtm-workflow/templates/lib/agent.ts
+++ b/skills/gtm-workflow/templates/lib/agent.ts
@@ -1,4 +1,4 @@
-// gtm-lib v9
+// gtm-lib v10
 // Call agent() from inside a "use step" function; see the workflow contract for the step rules.
 import { spawn } from "node:child_process";
 import { constants } from "node:fs";
@@ -7,12 +7,19 @@ import { tmpdir } from "node:os";
 import { delimiter, join } from "node:path";
 import { generateText, gateway, jsonSchema, Output, stepCountIs } from "ai";
 import { z } from "zod";
-import { provider, type PaidCallMeta } from "./provider";
+import {
+  provider,
+  ProviderPreCallError,
+  type PaidCallMeta,
+} from "./provider";
+import { redact } from "./redact";
 
-export type AgentTools = "none" | "web";
+export type AgentTools = "none" | "web" | "host-default";
 
 export interface AgentInput<T extends z.ZodTypeAny> {
   prompt: string;
+  context?: string;
+  contextId?: string;
   schema: T;
   meta: PaidCallMeta;
   tools?: AgentTools;
@@ -20,6 +27,7 @@ export interface AgentInput<T extends z.ZodTypeAny> {
   maxUsd?: number;
   timeoutMs?: number;
   ttlMs?: number;
+  signal?: AbortSignal;
 }
 
 type Context = {
@@ -34,6 +42,7 @@ type Context = {
 type CliBackend = {
   bin: string;
   webSafe: boolean;
+  noToolsSafe: boolean;
   args: (context: Context) => string[];
   parse: (stdout: string, context: Context) => Promise<BackendResult>;
 };
@@ -48,6 +57,7 @@ const CLI: Record<string, CliBackend> = {
   claude: {
     bin: "claude",
     webSafe: true,
+    noToolsSafe: true,
     args: (context) => [
       "-p",
       context.prompt,
@@ -67,7 +77,9 @@ const CLI: Record<string, CliBackend> = {
             "--max-turns",
             "30",
           ]
-        : ["--tools", "", "--max-turns", "3"]),
+        : context.tools === "none"
+          ? ["--tools", "", "--max-turns", "3"]
+          : ["--max-turns", "30"]),
       ...(context.maxUsd
         ? ["--max-budget-usd", String(context.maxUsd)]
         : []),
@@ -90,6 +102,7 @@ const CLI: Record<string, CliBackend> = {
   codex: {
     bin: "codex",
     webSafe: false,
+    noToolsSafe: false,
     args: (context) => [
       "exec",
       "--output-schema",
@@ -110,6 +123,7 @@ const CLI: Record<string, CliBackend> = {
   cursor: {
     bin: "agent",
     webSafe: false,
+    noToolsSafe: false,
     args: (context) => [
       "-p",
       context.prompt + JSON_INSTRUCTION(context.schemaJson),
@@ -122,6 +136,7 @@ const CLI: Record<string, CliBackend> = {
   gemini: {
     bin: "gemini",
     webSafe: false,
+    noToolsSafe: false,
     args: (context) => [
       "-p",
       context.prompt + JSON_INSTRUCTION(context.schemaJson),
@@ -134,6 +149,7 @@ const CLI: Record<string, CliBackend> = {
   opencode: {
     bin: "opencode",
     webSafe: false,
+    noToolsSafe: false,
     args: (context) => [
       "run",
       "--format",
@@ -157,14 +173,27 @@ export async function agent<T extends z.ZodTypeAny>(
   input: AgentInput<T>,
 ): Promise<z.infer<T>> {
   const schemaJson = strictSchema(z.toJSONSchema(input.schema));
+  const prompt = input.context
+    ? `${input.prompt}\n\nContext${input.contextId ? ` (${input.contextId})` : ""}:\n${input.context}`
+    : input.prompt;
   const runtimeInput: RuntimeInput = {
-    prompt: input.prompt,
+    prompt,
     schemaJson,
     tools: input.tools ?? "none",
     maxUsd: input.maxUsd,
     timeoutMs: input.timeoutMs,
+    signal: input.signal,
   };
   const backend = await pickBackend();
+  if (
+    backend !== API_BACKEND &&
+    runtimeInput.tools === "none" &&
+    !CLI[backend].noToolsSafe
+  ) {
+    throw new ProviderPreCallError(
+      `${backend} cannot enforce tools: "none". Use claude or api for untrusted input, or pass tools: "host-default" only after accepting host tool access.`,
+    );
+  }
   const model =
     process.env.GTM_AGENT_MODEL ??
     (backend === API_BACKEND ? "anthropic/claude-opus-5" : "default");
@@ -172,13 +201,15 @@ export async function agent<T extends z.ZodTypeAny>(
     name: "agent",
     endpoint: `${backend}/${model}`,
     input: {
-      prompt: input.prompt,
+      prompt,
+      contextId: input.contextId ?? null,
       schema: schemaJson,
       tools: runtimeInput.tools,
     },
     schema: input.schema,
     ttlMs: input.ttlMs ?? 30 * 24 * 60 * 60 * 1_000,
     costUsd: input.maxUsd,
+    costSource: "projected",
     meta: input.meta,
     call: async () => {
       const called =
@@ -200,6 +231,7 @@ type RuntimeInput = {
   tools: AgentTools;
   maxUsd?: number;
   timeoutMs?: number;
+  signal?: AbortSignal;
 };
 
 async function pickBackend(): Promise<string> {
@@ -242,6 +274,11 @@ async function viaCli(name: string, input: RuntimeInput) {
       `${name} cannot be restricted to web tools; use claude, set GTM_AGENT_BACKEND=api, or run without web tools.`,
     );
   }
+  if (input.tools === "none" && !backend.noToolsSafe) {
+    throw new ProviderPreCallError(
+      `${name} cannot enforce tools: "none" and was stopped before spawn.`,
+    );
+  }
 
   const cwd = await mkdtemp(join(tmpdir(), "gtm-agent-"));
   try {
@@ -268,7 +305,8 @@ async function viaCli(name: string, input: RuntimeInput) {
     const stdout = await run(backend.bin, backend.args(context), {
       cwd,
       env,
-      timeoutMs: input.timeoutMs ?? 300_000,
+      timeoutMs: input.timeoutMs ?? 240_000,
+      signal: input.signal,
     });
     return await backend.parse(stdout, context);
   } finally {
@@ -278,7 +316,10 @@ async function viaCli(name: string, input: RuntimeInput) {
 
 async function viaApi(input: RuntimeInput): Promise<BackendResult> {
   const model = process.env.GTM_AGENT_MODEL ?? "anthropic/claude-opus-5";
-  const abortSignal = AbortSignal.timeout(input.timeoutMs ?? 300_000);
+  const timeoutSignal = AbortSignal.timeout(input.timeoutMs ?? 240_000);
+  const abortSignal = input.signal
+    ? AbortSignal.any([timeoutSignal, input.signal])
+    : timeoutSignal;
   const output = Output.object({ schema: jsonSchema(input.schemaJson) });
   const costs: number[] = [];
   const record = (result: { providerMetadata?: Record<string, unknown> }) => {
@@ -354,7 +395,12 @@ function finish(value: unknown, costs: number[]): BackendResult {
 function run(
   bin: string,
   args: string[],
-  options: { cwd: string; env: Record<string, string>; timeoutMs: number },
+  options: {
+    cwd: string;
+    env: Record<string, string>;
+    timeoutMs: number;
+    signal?: AbortSignal;
+  },
 ): Promise<string> {
   return new Promise((resolve, reject) => {
     const child = spawn(bin, args, {
@@ -375,14 +421,24 @@ function run(
       reject(new Error(`${bin} timed out after ${options.timeoutMs}ms`));
     }, options.timeoutMs);
 
+    const abort = () => {
+      try {
+        process.kill(-child.pid!, "SIGKILL");
+      } catch {}
+      reject(options.signal?.reason ?? new Error(`${bin} aborted`));
+    };
+    options.signal?.addEventListener("abort", abort, { once: true });
+
     child.on("error", (error) => {
       clearTimeout(timer);
-      reject(error);
+      options.signal?.removeEventListener("abort", abort);
+      reject(new ProviderPreCallError(error.message));
     });
     child.on("close", (code) => {
       clearTimeout(timer);
+      options.signal?.removeEventListener("abort", abort);
       if (code === 0) resolve(stdout);
-      else reject(new Error(`${bin} exited ${code}: ${stderr.slice(0, 500)}`));
+      else reject(new Error(`${bin} exited ${code}: ${redact(stderr)}`));
     });
   });
 }

--- a/skills/gtm-workflow/templates/lib/approve.ts
+++ b/skills/gtm-workflow/templates/lib/approve.ts
@@ -1,4 +1,4 @@
-// gtm-lib v9
+// gtm-lib v10
 import { defineHook, sleep } from "workflow";
 import { z } from "zod";
 import {
@@ -6,17 +6,30 @@ import {
   recordWorkflowProgressAndStatus,
 } from "./steps";
 
-const approvalHook = defineHook({
-  schema: z.object({
-    approved: z.boolean(),
-    comment: z.string().nullable().default(null),
-  }),
+export const approvalDecision = z.object({
+  approved: z.boolean(),
+  comment: z.string().nullable().default(null),
+});
+
+export const approvalHook = defineHook({ schema: approvalDecision });
+export const triggerHook = defineHook({
+  schema: z.record(z.string(), z.unknown()),
+});
+export const cancellationHook = defineHook({
+  schema: z.object({ reason: z.string().nullable().default(null) }),
 });
 
 export type WorkflowMeta = {
   runKey: string;
   slug: string;
   checkpoint: number | null;
+  scheduledFor?: string | null;
+};
+
+export type ApprovalResult = {
+  approved: boolean;
+  comment: string | null;
+  outcome: "approved" | "denied" | "timed_out";
 };
 
 export async function approve(input: {
@@ -24,9 +37,11 @@ export async function approve(input: {
   summary: string;
   meta: WorkflowMeta;
   timeoutMs?: number;
-}): Promise<{ approved: boolean; comment: string | null }> {
-  if (input.stage.includes(".")) throw new Error("Approval stage names cannot contain dots.");
-  const token = `${input.meta.slug}.${input.meta.runKey}.${input.stage}`;
+}): Promise<ApprovalResult> {
+  if (input.stage.includes(".")) {
+    throw new Error("Approval stage names cannot contain dots.");
+  }
+  const token = approvalToken(input.meta, input.stage);
   const pending = approvalHook.create({ token });
   const approval = { stage: input.stage, token, summary: input.summary };
   await recordWorkflowProgressAndStatus(input.meta.runKey, {
@@ -40,18 +55,35 @@ export async function approve(input: {
       kind: "timeout" as const,
     })),
   ]);
+  await pending.dispose();
+
   const payload =
     winner.kind === "hook"
       ? winner.payload
       : { approved: false, comment: "timeout" };
-  if (winner.kind === "timeout") await pending.dispose();
-
+  const outcome =
+    winner.kind === "timeout"
+      ? "timed_out"
+      : payload.approved
+        ? "approved"
+        : "denied";
   await recordWorkflowProgressAndStatus(input.meta.runKey, {
-    status: "running",
+    status:
+      outcome === "approved"
+        ? "running"
+        : outcome === "timed_out"
+          ? "timed_out"
+          : "stopped",
+    stop_reason:
+      outcome === "approved"
+        ? null
+        : outcome === "timed_out"
+          ? "approval_timeout"
+          : "operator_denied",
     approval: { ...approval, ...payload },
     resolved: true,
   });
-  return payload;
+  return { ...payload, outcome };
 }
 
 export async function checkpoint(
@@ -59,13 +91,15 @@ export async function checkpoint(
   state: {
     completed: number;
     failed: number;
-    /** Retained for v8 workflow compatibility; v9 reads actual spend from the ledger. */
+    /** Retained for v8 workflow compatibility; v10 reads actual spend from the ledger. */
     spentUsd: number;
     projectedRemainingUsd: number;
     table: string;
   },
-): Promise<{ approved: boolean; comment: string | null }> {
-  if (meta.checkpoint === null) return { approved: true, comment: null };
+): Promise<ApprovalResult> {
+  if (meta.checkpoint === null) {
+    return { approved: true, comment: null, outcome: "approved" };
+  }
   const done = state.completed + state.failed;
   const spentUsd = await getActualRunCostUsd(meta.runKey);
   await recordWorkflowProgressAndStatus(meta.runKey, {
@@ -79,4 +113,34 @@ export async function checkpoint(
     meta,
     summary: `${done} rows done, ${state.failed} failed, $${spentUsd.toFixed(2)} spent, $${state.projectedRemainingUsd.toFixed(2)} projected for the remaining rows; open ${state.table} in Studio`,
   });
+}
+
+export async function waitForTrigger(
+  meta: WorkflowMeta,
+): Promise<Record<string, unknown>> {
+  const token = triggerToken(meta);
+  const pending = triggerHook.create({ token });
+  await recordWorkflowProgressAndStatus(meta.runKey, {
+    status: "waiting",
+    trigger_token: token,
+  });
+  const payload = await pending;
+  await pending.dispose();
+  await recordWorkflowProgressAndStatus(meta.runKey, {
+    status: "running",
+    trigger_token: null,
+  });
+  return payload;
+}
+
+export function approvalToken(meta: WorkflowMeta, stage: string): string {
+  return `${meta.slug}.${meta.runKey}.${stage}`;
+}
+
+export function triggerToken(meta: WorkflowMeta): string {
+  return `${meta.slug}.${meta.runKey}.trigger`;
+}
+
+export function cancellationToken(meta: WorkflowMeta): string {
+  return `${meta.slug}.${meta.runKey}.cancel`;
 }

--- a/skills/gtm-workflow/templates/lib/db-url.ts
+++ b/skills/gtm-workflow/templates/lib/db-url.ts
@@ -1,4 +1,4 @@
-// gtm-lib v9
+// gtm-lib v10
 import { mkdirSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 

--- a/skills/gtm-workflow/templates/lib/db.ts
+++ b/skills/gtm-workflow/templates/lib/db.ts
@@ -1,20 +1,17 @@
-// gtm-lib v9
+// gtm-lib v10
 import {
   createClient as createWebClient,
   type Client,
 } from "@libsql/client/web";
-import {
-  and,
-  eq,
-  getTableColumns,
-  or,
-  sql,
-} from "drizzle-orm";
+import { and, eq, getTableColumns, or, sql } from "drizzle-orm";
 import type { LibSQLDatabase } from "drizzle-orm/libsql/driver-core";
 import { drizzle as drizzleWeb } from "drizzle-orm/libsql/web";
 import { getRun } from "workflow/api";
+import { WorkflowRunFailedError } from "workflow/errors";
 import { getDatabaseConfig } from "./db-url";
+import { redact } from "./redact";
 import {
+  enrichmentRuns,
   workflowRuns,
   type WorkflowRunInsert,
   type WorkflowRunRow,
@@ -84,21 +81,37 @@ export async function upsertRows(
     throw new Error("A workflow table must declare an updated_at column.");
   }
 
-  const set = Object.fromEntries(
-    Object.entries(columns)
-      .filter(([property]) => property !== "key")
-      .map(([property, column]) => [
-        property,
-        sql.raw(`excluded."${column.name.replaceAll('"', '""')}"`),
-      ]),
-  );
-  const chunkSize = Math.max(1, Math.floor(900 / Object.keys(columns).length));
+  const groups = new Map<string, Record<string, unknown>[]>();
+  for (const row of rows) {
+    const properties = Object.keys(row)
+      .filter((property) => property in columns)
+      .sort();
+    if (!properties.includes("key")) throw new Error("Every upsert row must include key.");
+    if (!properties.includes("updatedAt")) {
+      throw new Error("Every upsert row must include updatedAt.");
+    }
+    const signature = properties.join("\u0000");
+    groups.set(signature, [...(groups.get(signature) ?? []), row]);
+  }
+
   const db = await getDb();
-  for (let index = 0; index < rows.length; index += chunkSize) {
-    await db
-      .insert(table)
-      .values(rows.slice(index, index + chunkSize))
-      .onConflictDoUpdate({ target: key, set });
+  for (const [signature, group] of groups) {
+    const properties = signature.split("\u0000");
+    const set = Object.fromEntries(
+      properties
+        .filter((property) => property !== "key")
+        .map((property) => {
+          const column = columns[property];
+          return [property, sql.raw(`excluded."${column.name.replaceAll('"', '""')}"`)];
+        }),
+    );
+    const chunkSize = Math.max(1, Math.floor(900 / properties.length));
+    for (let index = 0; index < group.length; index += chunkSize) {
+      await db
+        .insert(table)
+        .values(group.slice(index, index + chunkSize))
+        .onConflictDoUpdate({ target: key, set });
+    }
   }
   return rows.length;
 }
@@ -113,7 +126,13 @@ export async function updateRunPlain(
   patch: Partial<Omit<WorkflowRunInsert, "runKey">>,
 ): Promise<void> {
   const db = await getDb();
-  await db.update(workflowRuns).set(patch).where(eq(workflowRuns.runKey, runKey));
+  const safePatch = {
+    ...patch,
+    ...(patch.error !== undefined && patch.error !== null
+      ? { error: redact(patch.error) }
+      : {}),
+  };
+  await db.update(workflowRuns).set(safePatch).where(eq(workflowRuns.runKey, runKey));
 }
 
 export async function findLiveRun(
@@ -130,6 +149,25 @@ export async function findLiveRun(
           eq(workflowRuns.path, path),
           eq(workflowRuns.inputHash, inputHash),
           sql`${workflowRuns.finishedAt} IS NULL`,
+        ),
+      )
+      .limit(1)
+  )[0];
+}
+
+export async function findScheduledRun(
+  path: string,
+  scheduledFor: string,
+): Promise<WorkflowRunRow | undefined> {
+  const db = await getDb();
+  return (
+    await db
+      .select()
+      .from(workflowRuns)
+      .where(
+        and(
+          eq(workflowRuns.path, path),
+          eq(workflowRuns.scheduledFor, scheduledFor),
         ),
       )
       .limit(1)
@@ -154,17 +192,35 @@ export async function getRunRow(
   )[0];
 }
 
+export async function getRunCostSources(runKey: string) {
+  const db = await getDb();
+  return db
+    .select({
+      source: enrichmentRuns.costSource,
+      calls: sql<number>`count(*)`,
+      costUsd: sql<number>`coalesce(sum(${enrichmentRuns.costUsd}), 0)`,
+    })
+    .from(enrichmentRuns)
+    .where(eq(enrichmentRuns.runKey, runKey))
+    .groupBy(enrichmentRuns.costSource);
+}
+
 export async function reconcileRun(runKey: string): Promise<WorkflowRunRow> {
-  const row = await getRunRow(runKey);
+  let row = await getRunRow(runKey);
   if (!row) throw new Error(`Unknown run ${runKey}`);
-  if (row.finishedAt !== null || !["running", "waiting"].includes(row.status)) {
+  if (
+    row.finishedAt !== null ||
+    !["running", "waiting", "cancelling"].includes(row.status)
+  ) {
     return row;
   }
 
   const now = Date.now();
   if (!row.runId) {
-    if (now - row.startedAt < 120_000) return row;
-    await updateRunPlain(runKey, {
+    if (now - row.startedAt < 10 * 60_000) return row;
+    row = (await getRunRow(runKey))!;
+    if (row.runId || row.finishedAt !== null) return row;
+    await finishRun(runKey, {
       status: "failed",
       error: "start not recorded",
       finishedAt: now,
@@ -174,7 +230,7 @@ export async function reconcileRun(runKey: string): Promise<WorkflowRunRow> {
 
   const run = getRun(row.runId);
   if (!(await run.exists)) {
-    await updateRunPlain(runKey, {
+    await finishRun(runKey, {
       status: "failed",
       error: "run state expired",
       finishedAt: now,
@@ -183,30 +239,181 @@ export async function reconcileRun(runKey: string): Promise<WorkflowRunRow> {
   }
 
   const sdkStatus = await run.status;
+  if (
+    ["completed", "failed", "cancelled"].includes(sdkStatus) &&
+    row.status === "cancelling" &&
+    (await hasPendingRunCalls(runKey)) &&
+    (row.cancelRequestedAt === null || now - row.cancelRequestedAt < 6 * 60_000)
+  ) {
+    return row;
+  }
   const status: WorkflowStatus | undefined =
-    sdkStatus === "completed"
+    row.status === "cancelling" &&
+    ["completed", "failed", "cancelled"].includes(sdkStatus)
+      ? "cancelled"
+      : sdkStatus === "completed"
       ? "completed"
       : sdkStatus === "failed"
         ? "failed"
         : sdkStatus === "cancelled"
           ? "cancelled"
           : undefined;
-  if (status) {
-    await updateRunPlain(runKey, { status, finishedAt: now });
-    return (await getRunRow(runKey))!;
+  if (!status) return row;
+
+  let error: string | undefined;
+  let failedStep: string | undefined;
+  if (status === "failed") {
+    try {
+      await run.returnValue;
+    } catch (caught) {
+      const cause = WorkflowRunFailedError.is(caught) ? caught.cause : caught;
+      error = redact(cause);
+      failedStep = inferFailedStep(cause);
+    }
   }
-  return row;
+  await finishRun(runKey, {
+    status,
+    ...(error ? { error } : {}),
+    ...(failedStep ? { failedStep } : {}),
+    finishedAt: now,
+  });
+  return (await getRunRow(runKey))!;
+}
+
+async function hasPendingRunCalls(runKey: string): Promise<boolean> {
+  const db = await getDb();
+  return Boolean(
+    (
+      await db
+        .select({ id: enrichmentRuns.id })
+        .from(enrichmentRuns)
+        .where(
+          and(
+            eq(enrichmentRuns.runKey, runKey),
+            eq(enrichmentRuns.status, "pending"),
+          ),
+        )
+        .limit(1)
+    )[0],
+  );
+}
+
+async function finishRun(
+  runKey: string,
+  patch: Partial<Omit<WorkflowRunInsert, "runKey">>,
+) {
+  const db = await getDb();
+  await db
+    .update(enrichmentRuns)
+    .set({
+      status: "lost",
+      errorKind: "lost",
+      error: "paid call outcome unavailable after terminal run",
+    })
+    .where(
+      and(
+        eq(enrichmentRuns.runKey, runKey),
+        eq(enrichmentRuns.status, "pending"),
+      ),
+    );
+  const cost = (
+    await db
+      .select({ costUsd: sql<number>`coalesce(sum(${enrichmentRuns.costUsd}), 0)` })
+      .from(enrichmentRuns)
+      .where(eq(enrichmentRuns.runKey, runKey))
+  )[0];
+  await updateRunPlain(runKey, { ...patch, costUsd: Number(cost?.costUsd ?? 0) });
+}
+
+function inferFailedStep(cause: unknown): string | undefined {
+  if (cause && typeof cause === "object") {
+    const named = (cause as { stepName?: unknown }).stepName;
+    if (typeof named === "string" && named) return named;
+    const stack = (cause as { stack?: unknown }).stack;
+    if (typeof stack === "string") {
+      const match = stack.match(/\bat\s+([A-Za-z_$][\w$]*)\s*\(/);
+      if (match && match[1] !== "Error") return match[1];
+    }
+  }
+  return undefined;
+}
+
+export function assertReadOnlyQuery(query: string): string {
+  const trimmed = query.trim().replace(/;+\s*$/, "");
+  const visible = maskSqlLiteralsAndComments(trimmed);
+  if (!/^\s*(select|with)\b/i.test(visible) || visible.includes(";")) {
+    throw new Error("query accepts one read-only SELECT statement");
+  }
+  const forbidden = [
+    "delete",
+    "update",
+    "insert",
+    "replace",
+    "drop",
+    "alter",
+    "create",
+    "attach",
+    "detach",
+    "pragma",
+    "vacuum",
+    "reindex",
+  ];
+  const match = visible.match(new RegExp(`\\b(${forbidden.join("|")})\\b`, "i"));
+  if (match) throw new Error(`query is read-only; ${match[1].toUpperCase()} is not allowed`);
+  return trimmed;
 }
 
 export async function executeReadOnly(query: string): Promise<Record<string, unknown>[]> {
-  const trimmed = query.trim().replace(/;+\s*$/, "");
-  if (!/^(select|with)\b/i.test(trimmed) || trimmed.includes(";")) {
-    throw new Error("query accepts one read-only SELECT statement");
-  }
+  const statement = assertReadOnlyQuery(query);
   const client = await getClient();
   if (getDatabaseConfig().dialect === "sqlite") {
     await client.execute("PRAGMA query_only=1");
   }
-  const result = await client.execute(trimmed);
+  const result = await client.execute(statement);
   return result.rows.map((row) => ({ ...row }));
+}
+
+function maskSqlLiteralsAndComments(sqlText: string): string {
+  let result = "";
+  let index = 0;
+  while (index < sqlText.length) {
+    const current = sqlText[index];
+    const next = sqlText[index + 1];
+    if (current === "-" && next === "-") {
+      const end = sqlText.indexOf("\n", index + 2);
+      const length = (end < 0 ? sqlText.length : end) - index;
+      result += " ".repeat(length);
+      index += length;
+      continue;
+    }
+    if (current === "/" && next === "*") {
+      const end = sqlText.indexOf("*/", index + 2);
+      const length = (end < 0 ? sqlText.length : end + 2) - index;
+      result += " ".repeat(length);
+      index += length;
+      continue;
+    }
+    if (["'", '"', "`"].includes(current)) {
+      const quote = current;
+      result += " ";
+      index += 1;
+      while (index < sqlText.length) {
+        result += " ";
+        if (sqlText[index] === quote) {
+          if (sqlText[index + 1] === quote) {
+            result += " ";
+            index += 2;
+            continue;
+          }
+          index += 1;
+          break;
+        }
+        index += 1;
+      }
+      continue;
+    }
+    result += current;
+    index += 1;
+  }
+  return result;
 }

--- a/skills/gtm-workflow/templates/lib/migration-ledger.ts
+++ b/skills/gtm-workflow/templates/lib/migration-ledger.ts
@@ -1,0 +1,39 @@
+// gtm-lib v10
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { createClient } from "@libsql/client";
+
+export async function verifyMigrationLedger(input: {
+  root: string;
+  url: string;
+  authToken?: string;
+}): Promise<number> {
+  const journal = JSON.parse(
+    await readFile(join(input.root, "drizzle", "meta", "_journal.json"), "utf8"),
+  ) as { entries?: { tag?: string }[] };
+  if (!Array.isArray(journal.entries)) {
+    throw new Error("drizzle/meta/_journal.json has no entries array");
+  }
+
+  const expected = new Map<string, string>();
+  for (const entry of journal.entries) {
+    if (!entry.tag) throw new Error("Drizzle journal entry has no tag");
+    const file = `drizzle/${entry.tag}.sql`;
+    const contents = await readFile(join(input.root, file));
+    expected.set(createHash("sha256").update(contents).digest("hex"), file);
+  }
+
+  const client = createClient({ url: input.url, authToken: input.authToken });
+  try {
+    const result = await client.execute("SELECT hash FROM __drizzle_migrations");
+    for (const row of result.rows) expected.delete(String(row.hash));
+  } finally {
+    client.close();
+  }
+
+  if (expected.size > 0) {
+    throw new Error(`Migration ledger is missing: ${[...expected.values()].join(", ")}`);
+  }
+  return journal.entries.length;
+}

--- a/skills/gtm-workflow/templates/lib/provider.ts
+++ b/skills/gtm-workflow/templates/lib/provider.ts
@@ -1,11 +1,41 @@
-// gtm-lib v9
+// gtm-lib v10
 import { createHash, randomUUID } from "node:crypto";
 import { and, eq } from "drizzle-orm";
 import { z } from "zod";
 import { getDb } from "./db";
-import { enrichmentCache, enrichmentRuns } from "./schema";
+import { redact, redactedError } from "./redact";
+import {
+  enrichmentCache,
+  enrichmentRuns,
+  type CostSource,
+  type EnrichmentErrorKind,
+  type EnrichmentStatus,
+} from "./schema";
 
 export type PaidCallMeta = { runKey: string; slug: string };
+
+export class ProviderAuthError extends Error {
+  readonly providerErrorKind = "provider_auth";
+  override name = "ProviderAuthError";
+
+  constructor(message: string) {
+    super(`[provider_auth] ${message}`);
+  }
+}
+
+export class ProviderQuotaError extends Error {
+  readonly providerErrorKind = "provider_quota";
+  override name = "ProviderQuotaError";
+
+  constructor(message: string) {
+    super(`[provider_quota] ${message}`);
+  }
+}
+
+export class ProviderPreCallError extends Error {
+  readonly providerErrorKind = "pre_call";
+  override name = "ProviderPreCallError";
+}
 
 export type ProviderInput<T extends z.ZodTypeAny> = {
   name: string;
@@ -14,6 +44,7 @@ export type ProviderInput<T extends z.ZodTypeAny> = {
   schema: T;
   ttlMs: number;
   costUsd?: number;
+  costSource?: Exclude<CostSource, "reported">;
   call: () => Promise<
     | z.input<T>
     | { value: z.input<T>; raw?: unknown; costUsd?: number }
@@ -27,6 +58,7 @@ export type ProviderInput<T extends z.ZodTypeAny> = {
 export type PaidCallResult<T> = {
   value: T;
   costUsd: number;
+  costSource: CostSource;
   status: "cache_hit" | "success" | "empty";
 };
 
@@ -37,6 +69,7 @@ export async function provider<T extends z.ZodTypeAny>(
   const canonical = stableJson(input.input);
   const inputsHash = createHash("sha256").update(canonical).digest("hex");
   const now = Date.now();
+  const acceptedCostSource = input.costSource ?? "fixed";
   const cache = (
     await db
       .select()
@@ -52,11 +85,51 @@ export async function provider<T extends z.ZodTypeAny>(
   )[0];
 
   if (cache && cache.expiresAt > now) {
-    const raw = JSON.parse(cache.raw ?? cache.value);
-    const value = input.schema.parse(input.parseRaw ? input.parseRaw(raw) : raw);
-    await writeLedger(input, inputsHash, "cache_hit", 0, null);
-    return { value, costUsd: 0, status: "cache_hit" };
+    try {
+      const raw = JSON.parse(cache.raw ?? cache.value);
+      const value = input.schema.parse(input.parseRaw ? input.parseRaw(raw) : raw);
+      await insertLedger(input, {
+        inputsHash,
+        status: "cache_hit",
+        costUsd: 0,
+        costSource: acceptedCostSource,
+        error: null,
+        errorKind: null,
+      });
+      return {
+        value,
+        costUsd: 0,
+        costSource: acceptedCostSource,
+        status: "cache_hit",
+      };
+    } catch (error) {
+      await insertLedger(input, {
+        inputsHash,
+        status: "error",
+        costUsd: 0,
+        costSource: acceptedCostSource,
+        error: redact(error),
+        errorKind: "cache_parse",
+      });
+      throw redactedError(error);
+    }
   }
+
+  const ledgerId = randomUUID();
+  await db.insert(enrichmentRuns).values({
+    id: ledgerId,
+    runKey: input.meta.runKey,
+    workflow: input.meta.slug,
+    provider: input.name,
+    endpoint: input.endpoint,
+    inputsHash,
+    status: "pending",
+    costUsd: input.costUsd ?? 0,
+    costSource: acceptedCostSource,
+    error: null,
+    errorKind: null,
+    createdAt: now,
+  });
 
   try {
     const called = await input.call();
@@ -64,47 +137,70 @@ export async function provider<T extends z.ZodTypeAny>(
     const value = input.schema.parse(reported.value);
     const empty = input.isEmpty?.(value) ?? isEmpty(value);
     const costUsd = reported.costUsd ?? input.costUsd ?? 0;
-    await db
-      .insert(enrichmentCache)
-      .values({
-        provider: input.name,
-        endpoint: input.endpoint,
-        inputsHash,
-        inputs: canonical,
-        raw: JSON.stringify(reported.raw),
-        value: JSON.stringify(value),
-        expiresAt: now + input.ttlMs,
-        createdAt: now,
-      })
-      .onConflictDoUpdate({
-        target: [
-          enrichmentCache.provider,
-          enrichmentCache.endpoint,
-          enrichmentCache.inputsHash,
-        ],
-        set: {
+    const costSource: CostSource =
+      reported.costUsd === undefined ? acceptedCostSource : "reported";
+    const status = empty ? "empty" : "success";
+    const raw = JSON.stringify(reported.raw) ?? null;
+    await db.batch([
+      db
+        .insert(enrichmentCache)
+        .values({
+          provider: input.name,
+          endpoint: input.endpoint,
+          inputsHash,
           inputs: canonical,
-          raw: JSON.stringify(reported.raw),
+          raw,
           value: JSON.stringify(value),
           expiresAt: now + input.ttlMs,
           createdAt: now,
-        },
-      });
-    const status = empty ? "empty" : "success";
-    await writeLedger(input, inputsHash, status, costUsd, null);
-    return { value, costUsd, status };
+        })
+        .onConflictDoUpdate({
+          target: [
+            enrichmentCache.provider,
+            enrichmentCache.endpoint,
+            enrichmentCache.inputsHash,
+          ],
+          set: {
+            inputs: canonical,
+            raw,
+            value: JSON.stringify(value),
+            expiresAt: now + input.ttlMs,
+            createdAt: now,
+          },
+        }),
+      db
+        .update(enrichmentRuns)
+        .set({ status, costUsd, costSource, error: null, errorKind: null })
+        .where(eq(enrichmentRuns.id, ledgerId)),
+    ]);
+    return { value, costUsd, costSource, status };
   } catch (error) {
-    await writeLedger(input, inputsHash, "error", input.costUsd ?? null, message(error));
-    throw error;
+    const errorKind = classifyError(error);
+    const costUsd = errorKind === "pre_call" ? 0 : input.costUsd ?? 0;
+    await db
+      .update(enrichmentRuns)
+      .set({
+        status: "error",
+        costUsd,
+        costSource: acceptedCostSource,
+        error: redact(error),
+        errorKind,
+      })
+      .where(eq(enrichmentRuns.id, ledgerId));
+    throw redactedError(error);
   }
 }
 
-async function writeLedger(
+async function insertLedger(
   input: Pick<ProviderInput<any>, "meta" | "name" | "endpoint">,
-  inputsHash: string,
-  status: "cache_hit" | "success" | "empty" | "error",
-  costUsd: number | null,
-  error: string | null,
+  row: {
+    inputsHash: string;
+    status: EnrichmentStatus;
+    costUsd: number | null;
+    costSource: CostSource;
+    error: string | null;
+    errorKind: EnrichmentErrorKind | null;
+  },
 ) {
   const db = await getDb();
   await db.insert(enrichmentRuns).values({
@@ -113,12 +209,29 @@ async function writeLedger(
     workflow: input.meta.slug,
     provider: input.name,
     endpoint: input.endpoint,
-    inputsHash,
-    status,
-    costUsd,
-    error,
+    inputsHash: row.inputsHash,
+    status: row.status,
+    costUsd: row.costUsd,
+    costSource: row.costSource,
+    error: row.error,
+    errorKind: row.errorKind,
     createdAt: Date.now(),
   });
+}
+
+function classifyError(error: unknown): EnrichmentErrorKind {
+  const kind =
+    error && typeof error === "object"
+      ? (error as { providerErrorKind?: unknown }).providerErrorKind
+      : undefined;
+  if (
+    kind === "pre_call" ||
+    kind === "provider_auth" ||
+    kind === "provider_quota"
+  ) {
+    return kind;
+  }
+  return "call";
 }
 
 function unwrapCallResult<T>(
@@ -128,7 +241,7 @@ function unwrapCallResult<T>(
     value &&
     typeof value === "object" &&
     "value" in value &&
-    ("costUsd" in value || Object.keys(value).length <= 2)
+    ("costUsd" in value || "raw" in value)
   ) {
     const reported = value as { value: T; raw?: unknown; costUsd?: number };
     return {
@@ -155,8 +268,4 @@ function stableJson(value: unknown): string {
       .join(",")}}`;
   }
   return JSON.stringify(value);
-}
-
-function message(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
 }

--- a/skills/gtm-workflow/templates/lib/redact.ts
+++ b/skills/gtm-workflow/templates/lib/redact.ts
@@ -1,0 +1,54 @@
+// gtm-lib v10
+const SECRET_NAME = /_(?:KEY|TOKEN|SECRET)$/i;
+const SENSITIVE_ASSIGNMENT =
+  /((?:["']?(?:api[_-]?key|apikey|key|token|secret|password|authorization)["']?)\s*[:=]\s*)(["']?)([^\s,;&"']+)(["']?)/gi;
+
+export function redact(value: unknown): string {
+  let text = value instanceof Error ? value.message : String(value ?? "");
+
+  text = text.replace(/https?:\/\/[^\s"'<>]+/gi, (candidate) => {
+    try {
+      const url = new URL(candidate);
+      url.search = "";
+      return url.toString();
+    } catch {
+      return candidate.replace(/\?.*$/, "");
+    }
+  });
+  text = text.replace(/\bBearer\s+[^\s,;]+/gi, "Bearer [REDACTED]");
+  text = text.replace(
+    SENSITIVE_ASSIGNMENT,
+    (_match, prefix: string, quote: string) => `${prefix}${quote}[REDACTED]${quote}`,
+  );
+
+  const environmentSecrets = Object.entries(process.env)
+    .filter(([name, secret]) => SECRET_NAME.test(name) && Boolean(secret))
+    .map(([, secret]) => secret!)
+    .sort((left, right) => right.length - left.length);
+  for (const secret of environmentSecrets) text = text.replaceAll(secret, "[REDACTED]");
+
+  return text.slice(0, 500);
+}
+
+export function redactValue(value: unknown): unknown {
+  if (typeof value === "string") return redact(value);
+  if (Array.isArray(value)) return value.map(redactValue);
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, item]) => [key, redactValue(item)]),
+    );
+  }
+  return value;
+}
+
+export function redactedError(error: unknown): Error {
+  const sanitized = new Error(redact(error));
+  if (error && typeof error === "object") {
+    sanitized.name = String((error as { name?: unknown }).name ?? "Error");
+    for (const key of ["providerErrorKind", "stepName", "code"] as const) {
+      const value = (error as Record<string, unknown>)[key];
+      if (value !== undefined) (sanitized as unknown as Record<string, unknown>)[key] = value;
+    }
+  }
+  return sanitized;
+}

--- a/skills/gtm-workflow/templates/lib/rows.ts
+++ b/skills/gtm-workflow/templates/lib/rows.ts
@@ -1,0 +1,191 @@
+// gtm-lib v10
+import {
+  cancellationHook,
+  cancellationToken,
+  checkpoint,
+  type WorkflowMeta,
+} from "./approve";
+import { redact } from "./redact";
+import {
+  getActualRunCostUsd,
+  getHeldRunReason,
+  registerWorkflowRun,
+  updateRun,
+} from "./steps";
+
+export type RowStepResult =
+  | { key: string; status?: "success"; value: Record<string, unknown> }
+  | { key: string; status: "empty"; value?: undefined };
+
+export type RunRowsTable = {
+  name: string;
+  save: (row: Record<string, unknown>) => Promise<void>;
+};
+
+export type RunRowsCaps = {
+  maxRows: number;
+  maxSpendUsd: number;
+  costPerRowUsd: number;
+};
+
+export async function runRows<TRow extends { key: string }>(input: {
+  rows: TRow[];
+  meta: WorkflowMeta;
+  table: RunRowsTable;
+  rowStep: (
+    row: TRow,
+    meta: WorkflowMeta,
+    signal: AbortSignal,
+  ) => Promise<RowStepResult>;
+  caps: RunRowsCaps;
+}) {
+  await registerWorkflowRun(input.meta.runKey);
+  const projected = input.rows.length * input.caps.costPerRowUsd;
+  if (
+    input.rows.length > input.caps.maxRows ||
+    projected > input.caps.maxSpendUsd
+  ) {
+    await updateRun(input.meta.runKey, {
+      status: "failed",
+      error: "accepted workflow limits exceeded",
+      stop_reason: "caps_exceeded",
+      completed: 0,
+      failed: 0,
+      finished: true,
+    });
+    throw new Error("Accepted workflow limits exceeded");
+  }
+
+  const completed: string[] = [];
+  const failed: { key: string; error: string }[] = [];
+  let success = 0;
+  let empty = 0;
+  let status: "completed" | "stopped" | "timed_out" | "cancelling" = "completed";
+  let stopReason: string | null = null;
+  let remainingKeys: string[] = [];
+  let failedStep: string | null = null;
+
+  const controller = new AbortController();
+  const cancel = cancellationHook.create({ token: cancellationToken(input.meta) });
+  const cancelled = cancel.then(({ reason }) => {
+    controller.abort(reason ?? "run cancelled");
+    return { cancelled: true as const };
+  });
+
+  try {
+    for (let index = 0; index < input.rows.length; index += 1) {
+      const row = input.rows[index];
+      try {
+        const outcome = await Promise.race([
+          input.rowStep(row, input.meta, controller.signal).then((value) => ({
+            cancelled: false as const,
+            value,
+          })),
+          cancelled,
+        ]);
+        if (!("value" in outcome)) {
+          status = "cancelling";
+          stopReason = "cancelled";
+          remainingKeys = input.rows.slice(index).map(({ key }) => key);
+          break;
+        }
+        if (outcome.value.status === "empty") {
+          empty += 1;
+          completed.push(outcome.value.key);
+        } else {
+          await input.table.save({ key: outcome.value.key, ...outcome.value.value });
+          success += 1;
+          completed.push(outcome.value.key);
+        }
+      } catch (error) {
+        if (controller.signal.aborted) {
+          status = "cancelling";
+          stopReason = "cancelled";
+          remainingKeys = input.rows.slice(index).map(({ key }) => key);
+          break;
+        }
+        const held = heldReason(error) ?? (await getHeldRunReason(input.meta.runKey));
+        if (held) {
+          status = "stopped";
+          stopReason = held;
+          remainingKeys = input.rows.slice(index + 1).map(({ key }) => key);
+          failed.push({ key: row.key, error: redact(error) });
+          failedStep = input.rowStep.name || "rowStep";
+          break;
+        }
+        failed.push({ key: row.key, error: redact(error) });
+        failedStep = input.rowStep.name || "rowStep";
+      }
+
+      const spentUsd = await getActualRunCostUsd(input.meta.runKey);
+      if (spentUsd > input.caps.maxSpendUsd) {
+        status = "stopped";
+        stopReason = "spend_cap";
+        remainingKeys = input.rows.slice(index + 1).map(({ key }) => key);
+        break;
+      }
+
+      const processed = completed.length + failed.length;
+      if (processed === input.meta.checkpoint) {
+        const decision = await checkpoint(input.meta, {
+          completed: completed.length,
+          failed: failed.length,
+          spentUsd,
+          projectedRemainingUsd:
+            (input.rows.length - processed) * input.caps.costPerRowUsd,
+          table: input.table.name,
+        });
+        if (!decision.approved) {
+          status = decision.outcome === "timed_out" ? "timed_out" : "stopped";
+          stopReason =
+            decision.outcome === "timed_out"
+              ? "approval_timeout"
+              : "operator_denied";
+          remainingKeys = input.rows.slice(index + 1).map(({ key }) => key);
+          break;
+        }
+      }
+    }
+  } finally {
+    await cancel.dispose();
+  }
+
+  await updateRun(input.meta.runKey, {
+    status,
+    completed: completed.length,
+    failed: failed.length,
+    cost_usd: await getActualRunCostUsd(input.meta.runKey),
+    stop_reason: stopReason,
+    remaining_keys: remainingKeys,
+    failed_step: failedStep,
+    finished: status !== "cancelling",
+  });
+  return {
+    status,
+    completed,
+    failed,
+    counts: { success, empty, failed: failed.length },
+    stopReason,
+    remainingKeys,
+  };
+}
+
+function heldReason(error: unknown): "provider_auth" | "provider_quota" | undefined {
+  if (!error || typeof error !== "object") return undefined;
+  const value = error as { providerErrorKind?: unknown; name?: unknown; message?: unknown };
+  if (
+    value.providerErrorKind === "provider_auth" ||
+    value.name === "ProviderAuthError" ||
+    (typeof value.message === "string" && value.message.startsWith("[provider_auth]"))
+  ) {
+    return "provider_auth";
+  }
+  if (
+    value.providerErrorKind === "provider_quota" ||
+    value.name === "ProviderQuotaError" ||
+    (typeof value.message === "string" && value.message.startsWith("[provider_quota]"))
+  ) {
+    return "provider_quota";
+  }
+  return undefined;
+}

--- a/skills/gtm-workflow/templates/lib/schema.ts
+++ b/skills/gtm-workflow/templates/lib/schema.ts
@@ -1,4 +1,4 @@
-// gtm-lib v9
+// gtm-lib v10
 import { sql } from "drizzle-orm";
 import {
   index,
@@ -10,11 +10,28 @@ import {
   uniqueIndex,
 } from "drizzle-orm/sqlite-core";
 
-export type EnrichmentStatus = "cache_hit" | "success" | "empty" | "error";
+export type EnrichmentStatus =
+  | "pending"
+  | "cache_hit"
+  | "success"
+  | "empty"
+  | "error"
+  | "lost";
+export type CostSource = "reported" | "fixed" | "projected";
+export type EnrichmentErrorKind =
+  | "pre_call"
+  | "call"
+  | "cache_parse"
+  | "provider_auth"
+  | "provider_quota"
+  | "lost";
 export type WorkflowStatus =
   | "running"
   | "waiting"
+  | "cancelling"
   | "completed"
+  | "stopped"
+  | "timed_out"
   | "failed"
   | "cancelled";
 
@@ -46,7 +63,9 @@ export const enrichmentRuns = sqliteTable(
     inputsHash: text("inputs_hash").notNull(),
     status: text("status").$type<EnrichmentStatus>().notNull(),
     costUsd: real("cost_usd"),
+    costSource: text("cost_source").$type<CostSource>().notNull().default("fixed"),
     error: text("error"),
+    errorKind: text("error_kind").$type<EnrichmentErrorKind>(),
     createdAt: integer("created_at").notNull(),
   },
   (table) => [index("enrichment_runs_run_key_idx").on(table.runKey)],
@@ -64,12 +83,19 @@ export const workflowRuns = sqliteTable(
     inputHash: text("input_hash").notNull(),
     status: text("status").$type<WorkflowStatus>().notNull(),
     error: text("error"),
+    stopReason: text("stop_reason"),
+    remainingKeys: text("remaining_keys"),
+    failedStep: text("failed_step"),
+    runUrl: text("run_url"),
     completed: integer("completed"),
     failed: integer("failed"),
     costUsd: real("cost_usd"),
     checkpoint: integer("checkpoint"),
     webhookUrl: text("webhook_url"),
+    triggerToken: text("trigger_token"),
     approval: text("approval"),
+    scheduledFor: text("scheduled_for"),
+    cancelRequestedAt: integer("cancel_requested_at"),
     startedAt: integer("started_at").notNull(),
     finishedAt: integer("finished_at"),
   },
@@ -77,6 +103,9 @@ export const workflowRuns = sqliteTable(
     uniqueIndex("workflow_runs_live_idx")
       .on(table.path, table.inputHash)
       .where(sql`finished_at IS NULL`),
+    uniqueIndex("workflow_runs_scheduled_idx")
+      .on(table.path, table.scheduledFor)
+      .where(sql`scheduled_for IS NOT NULL`),
   ],
 );
 

--- a/skills/gtm-workflow/templates/lib/steps.ts
+++ b/skills/gtm-workflow/templates/lib/steps.ts
@@ -1,7 +1,9 @@
-// gtm-lib v9
-import { eq, sql } from "drizzle-orm";
+// gtm-lib v10
+import { and, eq, or, sql } from "drizzle-orm";
+import { getWorkflowMetadata } from "workflow";
 import { getDb, updateRunPlain } from "./db";
-import { enrichmentRuns } from "./schema";
+import { redact, redactValue } from "./redact";
+import { enrichmentRuns, type WorkflowStatus } from "./schema";
 
 export type ApprovalState = {
   stage: string;
@@ -13,18 +15,32 @@ export type ApprovalState = {
 };
 
 export type RunPatch = {
-  status?: "running" | "waiting" | "completed" | "failed" | "cancelled";
+  status?: WorkflowStatus;
   run_id?: string | null;
   completed?: number | null;
   failed?: number | null;
   cost_usd?: number | null;
   checkpoint?: number | null;
   webhook_url?: string | null;
+  trigger_token?: string | null;
   approval?: ApprovalState | null;
   error?: string | null;
+  stop_reason?: string | null;
+  remaining_keys?: string[] | null;
+  failed_step?: string | null;
+  run_url?: string | null;
   finished?: boolean;
   resolved?: boolean;
 };
+
+export async function registerWorkflowRun(runKey: string): Promise<void> {
+  "use step";
+  const metadata = getWorkflowMetadata();
+  await updateRunPlain(runKey, {
+    runId: metadata.workflowRunId,
+    runUrl: metadata.url,
+  });
+}
 
 export async function recordWorkflowProgressAndStatus(
   runKey: string,
@@ -32,26 +48,42 @@ export async function recordWorkflowProgressAndStatus(
 ): Promise<void> {
   "use step";
   const now = Date.now();
+  const metadata = getWorkflowMetadata();
+  const safeApproval = patch.approval
+    ? (redactValue(patch.approval) as ApprovalState)
+    : patch.approval;
   const approval =
-    patch.approval && patch.resolved
-      ? { ...patch.approval, resolved_at: now }
-      : patch.approval;
+    safeApproval && patch.resolved
+      ? { ...safeApproval, resolved_at: now }
+      : safeApproval;
   const actualCostUsd =
     patch.cost_usd !== undefined || patch.finished
       ? await getActualRunCostUsd(runKey)
       : undefined;
   await updateRunPlain(runKey, {
+    runId: patch.run_id === undefined ? metadata.workflowRunId : patch.run_id,
+    runUrl: patch.run_url === undefined ? metadata.url : patch.run_url,
     ...(patch.status !== undefined ? { status: patch.status } : {}),
-    ...(patch.run_id !== undefined ? { runId: patch.run_id } : {}),
     ...(patch.completed !== undefined ? { completed: patch.completed } : {}),
     ...(patch.failed !== undefined ? { failed: patch.failed } : {}),
     ...(actualCostUsd !== undefined ? { costUsd: actualCostUsd } : {}),
     ...(patch.checkpoint !== undefined ? { checkpoint: patch.checkpoint } : {}),
     ...(patch.webhook_url !== undefined ? { webhookUrl: patch.webhook_url } : {}),
+    ...(patch.trigger_token !== undefined ? { triggerToken: patch.trigger_token } : {}),
     ...(approval !== undefined
       ? { approval: approval === null ? null : JSON.stringify(approval) }
       : {}),
-    ...(patch.error !== undefined ? { error: patch.error } : {}),
+    ...(patch.error !== undefined
+      ? { error: patch.error === null ? null : redact(patch.error) }
+      : {}),
+    ...(patch.stop_reason !== undefined ? { stopReason: patch.stop_reason } : {}),
+    ...(patch.remaining_keys !== undefined
+      ? {
+          remainingKeys:
+            patch.remaining_keys === null ? null : JSON.stringify(patch.remaining_keys),
+        }
+      : {}),
+    ...(patch.failed_step !== undefined ? { failedStep: patch.failed_step } : {}),
     ...(patch.finished ? { finishedAt: now } : {}),
   });
 }
@@ -70,4 +102,29 @@ export async function getActualRunCostUsd(runKey: string): Promise<number> {
       .where(eq(enrichmentRuns.runKey, runKey))
   )[0];
   return Number(row?.costUsd ?? 0);
+}
+
+export async function getHeldRunReason(
+  runKey: string,
+): Promise<"provider_auth" | "provider_quota" | undefined> {
+  "use step";
+  const db = await getDb();
+  const row = (
+    await db
+      .select({ errorKind: enrichmentRuns.errorKind })
+      .from(enrichmentRuns)
+      .where(
+        and(
+          eq(enrichmentRuns.runKey, runKey),
+          or(
+            eq(enrichmentRuns.errorKind, "provider_auth"),
+            eq(enrichmentRuns.errorKind, "provider_quota"),
+          ),
+        ),
+      )
+      .limit(1)
+  )[0];
+  return row?.errorKind === "provider_auth" || row?.errorKind === "provider_quota"
+    ? row.errorKind
+    : undefined;
 }

--- a/skills/gtm-workflow/templates/nitro.config.ts
+++ b/skills/gtm-workflow/templates/nitro.config.ts
@@ -1,4 +1,4 @@
-// gtm-lib v9
+// gtm-lib v10
 import { defineConfig } from "nitro";
 
 export default defineConfig({

--- a/skills/gtm-workflow/templates/package.json
+++ b/skills/gtm-workflow/templates/package.json
@@ -7,13 +7,14 @@
   },
   "type": "module",
   "scripts": {
-    "dev": "WORKFLOW_EMBEDDED_DATA_DIR=node_modules/.nitro/workflow WORKFLOW_LOCAL_HEADERS_TIMEOUT_MS=360000 WORKFLOW_LOCAL_BODY_TIMEOUT_MS=360000 nitro dev --port 3000",
+    "dev": "WORKFLOW_LOCAL_RECOVER_ACTIVE_RUNS=0 WORKFLOW_EMBEDDED_DATA_DIR=node_modules/.nitro/workflow WORKFLOW_LOCAL_HEADERS_TIMEOUT_MS=360000 WORKFLOW_LOCAL_BODY_TIMEOUT_MS=360000 nitro dev --port 3000",
     "build": "nitro build",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",
     "db:migrate:cloud": "node --env-file=.env.turso --import tsx scripts/migrate-cloud.ts",
+    "db:verify": "node --env-file-if-exists=.env --import tsx scripts/verify-migrations.ts",
     "db:studio": "drizzle-kit studio",
-    "db:studio:cloud": "node --env-file=.env.turso ./node_modules/drizzle-kit/bin.cjs studio",
+    "db:studio:cloud": "node --env-file=.env.turso -e \"if (!process.env.TURSO_READ_ONLY_AUTH_TOKEN) throw new Error('TURSO_READ_ONLY_AUTH_TOKEN is required'); process.env.TURSO_AUTH_TOKEN=process.env.TURSO_READ_ONLY_AUTH_TOKEN; import('./node_modules/drizzle-kit/bin.cjs')\" -- studio",
     "gtm": "node --env-file-if-exists=.env --import tsx scripts/gtm.ts"
   },
   "dependencies": {
@@ -32,6 +33,35 @@
     "typescript": "7.0.2"
   },
   "gtm": {
-    "libVersion": 9
+    "libVersion": 10,
+    "libHashes": {
+      "drizzle.config.ts": "c524efaaaf88e6fc1f91739d424b9e8f4cca653a756a427cb7102d0a873a8bb2",
+      "lib/agent.ts": "5678196a9eade6b4397c0cf9eaca7a0349305b710fcc4ef1205e495a78bc12cc",
+      "lib/approve.ts": "96d31f27e257563f88b851942353264a7603852c554afd71a40a9f7fff0cc654",
+      "lib/db-url.ts": "d02a5cd5c0cd54c18473bb0c078515c92ba9d7fcce590c5dcd4313ab017aa2d7",
+      "lib/db.ts": "d5bd2507d98ccf19a31bcd489b13edc225cd6cf65ea6f0b59288bbcb52867602",
+      "lib/migration-ledger.ts": "1c6b19af557f5994578b6cd48e539486323fb9a6ddbb9d977bbc2df3c09770fc",
+      "lib/provider.ts": "3d9aa084ba862b1a538b9d1e0495abf50187d994408d34ba9dc0c5e2c3f177a4",
+      "lib/redact.ts": "e429678f78a1eb5162889496b4d18aa4b9eb39d02a115550cdc593c6cb0a3616",
+      "lib/rows.ts": "94049beb69c3b8b6960ef7f0906fa5677d10066449bb791db799301cef0f8057",
+      "lib/schema.ts": "a24060198afa5552fb3d894007bffd5a395646a64d0fe57b0bd2ca13a1cfc4e7",
+      "lib/steps.ts": "da0c6c41e3876120ab6bad88c2fd4e4f5cc39901a246c08ba32dbd5a19b1b23f",
+      "nitro.config.ts": "b24142bc4a4ca1e3d9d59989e760293365cc111d9e99247abb49570635cd7f23",
+      "scripts/gtm.ts": "d2f1264a4242ed2cef672be99e2ca2fc82a3bde9e5fdbe659f04bd783c2e9aa3",
+      "scripts/migrate-cloud.ts": "c10c47367b9566b489f8f250e012d5927129ee0c951620908ee94a9478c5e53d",
+      "scripts/verify-migrations.ts": "61a56f4647f93cd63cb2338925d6c0cff57a83bb438af3b44b575d7d395a2a37",
+      "server/api/approve/[token].post.ts": "c5e386eff307ad7dc3ac65153435496b0974d1f6b32dc7d3811ebbaf0765a4b3",
+      "server/api/deployment.get.ts": "7f1612cd8f4768221f3ea2ca93b27c4c978802849eafe89d9baf125b3cab76b1",
+      "server/api/run/[...workflow].ts": "b6c732c0c9148b08ed8aacb97c3114508a3a8bbf6d657ad56621eaf48428dc64",
+      "server/api/runs/[runId].get.ts": "cc96f2f732482d0dc663925efdffaad2cc48cc119110e072357ceffd284f3549",
+      "server/api/runs/[runId]/cancel.post.ts": "7c71ab377812fe863c4155c9f6b8508a4505b14e86fb515a2c239419028e5630",
+      "server/api/runs/[runId]/trigger.post.ts": "546fbeedd4d93af5477fc01b3abc940774150ad955e453d472e580f318a512f0"
+    },
+    "validatedAgainst": {
+      "workflow": "5.0.0-beta.44",
+      "nitro": "3.0.260610-beta",
+      "drizzleKit": "0.31.10",
+      "node": "22"
+    }
   }
 }

--- a/skills/gtm-workflow/templates/scripts/gtm.ts
+++ b/skills/gtm-workflow/templates/scripts/gtm.ts
@@ -1,10 +1,14 @@
-// gtm-lib v9
+// gtm-lib v10
+import { createHash } from "node:crypto";
 import { spawn } from "node:child_process";
 import { existsSync } from "node:fs";
 import { readFile, readdir } from "node:fs/promises";
 import { basename, join, relative, resolve, sep } from "node:path";
+import { pathToFileURL } from "node:url";
 import { parseEnv } from "node:util";
+import { createScanner, LanguageVariant, SyntaxKind } from "typescript/unstable/ast";
 import { executeReadOnly } from "../lib/db";
+import { redact, redactValue } from "../lib/redact";
 
 type Flags = Record<string, string | boolean>;
 
@@ -24,7 +28,7 @@ main().catch((caught) => {
   const error =
     caught instanceof AppError
       ? caught
-      : new AppError("internal_error", caught instanceof Error ? caught.message : String(caught));
+      : new AppError("internal_error", redact(caught));
   process.stderr.write(`${JSON.stringify({ error: { code: error.code, message: error.message } })}\n`);
   process.exitCode = error.exitCode;
 });
@@ -69,10 +73,11 @@ async function run(args: string[]) {
     );
   }
   const body = JSON.parse(await readFile(resolve(inputPath), "utf8"));
-  const rows = rowCount(body);
-  const maxRows = exportedNumber(source, "MAX_ROWS");
-  const costPerRowUsd = exportedNumber(source, "COST_PER_ROW_USD");
-  const maxSpendUsd = exportedNumber(source, "MAX_SPEND_USD");
+  const loaded = await loadWorkflow(workflow, body);
+  const rows = Array.isArray(loaded.input?.rows) ? loaded.input.rows.length : 1;
+  const maxRows = loaded.maxRows;
+  const costPerRowUsd = loaded.costPerRowUsd;
+  const maxSpendUsd = loaded.maxSpendUsd;
   const projectedCostUsd = rows * costPerRowUsd;
   const stages = [...source.matchAll(/async function\s+([A-Za-z0-9_$]+)\s*\([^)]*\)\s*\{\s*["']use step["']/g)].map(
     (match) => match[1],
@@ -102,9 +107,20 @@ async function run(args: string[]) {
   const checkpoint = stringFlag(flags, "checkpoint");
   const url = new URL(`/api/run/${path}`, origin);
   if (checkpoint) url.searchParams.set("checkpoint", checkpoint);
+  const scheduledFor = stringFlag(flags, "scheduled-for");
+  if (scheduledFor) {
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(scheduledFor)) {
+      throw new AppError("invalid_scheduled_for", "--scheduled-for must be YYYY-MM-DD", 2);
+    }
+    url.searchParams.set("scheduled-for", scheduledFor);
+  }
+  const workspaceHead = await deploymentHead(workflow, origin);
   const started = await request(url, {
     method: "POST",
-    headers: authHeaders(),
+    headers: {
+      ...authHeaders(),
+      ...(workspaceHead ? { "x-gtm-workspace-head": workspaceHead } : {}),
+    },
     body: JSON.stringify(body),
   });
   if (!flags.wait) return print(started);
@@ -167,7 +183,8 @@ async function cancel(args: string[]) {
     headers: authHeaders(),
     body: JSON.stringify({ reason: stringFlag(flags, "reason") ?? null }),
   });
-  print(row);
+  if (!flags.wait) return print(row);
+  print(await poll(origin, row.runKey ?? identifier));
 }
 
 async function query(args: string[]) {
@@ -179,8 +196,16 @@ async function query(args: string[]) {
       throw new AppError("missing_cloud_env", ".env.turso is required with --cloud", 2);
     }
     const values = parseEnv(await readFile(join(root, ".env.turso"), "utf8"));
+    const readOnlyToken = values.TURSO_READ_ONLY_AUTH_TOKEN?.trim();
+    if (!readOnlyToken) {
+      throw new AppError(
+        "missing_read_only_token",
+        "TURSO_READ_ONLY_AUTH_TOKEN is required for query --cloud; the write token is never used.",
+        2,
+      );
+    }
     process.env.TURSO_DATABASE_URL = values.TURSO_DATABASE_URL;
-    process.env.TURSO_AUTH_TOKEN = values.TURSO_AUTH_TOKEN;
+    process.env.TURSO_AUTH_TOKEN = readOnlyToken;
   }
   const rows = await executeReadOnly(statement);
   const format = stringFlag(flags, "format") ?? "json";
@@ -215,13 +240,16 @@ async function check() {
     ) {
       throw new AppError("invalid_rows_input", `${relative(root, file)} rows input must include key`, 2);
     }
+    validateWorkflowSource(file, source, expected);
   }
+  await validateTableSources();
   await validateMigrationArtifacts();
 
   const packageJson = JSON.parse(await readFile(join(root, "package.json"), "utf8"));
   const expectedVersion = packageJson.gtm?.libVersion;
   for (const file of await headeredFiles()) {
-    const first = (await readFile(file, "utf8")).split("\n", 1)[0];
+    const contents = await readFile(file, "utf8");
+    const first = contents.split("\n", 1)[0];
     if (first !== `// gtm-lib v${expectedVersion}`) {
       throw new AppError(
         "lib_version_mismatch",
@@ -229,8 +257,179 @@ async function check() {
         2,
       );
     }
+    const path = relative(root, file).split(sep).join("/");
+    const expectedHash = packageJson.gtm?.libHashes?.[path];
+    const actualHash = createHash("sha256").update(contents).digest("hex");
+    if (!expectedHash) {
+      throw new AppError("lib_hash_missing", `${path} has no gtm.libHashes entry`, 2);
+    }
+    if (expectedHash !== actualHash) {
+      throw new AppError("lib_modified", `${path} was modified locally`, 2);
+    }
   }
-  print({ ok: true, workflows: workflows.length, libVersion: expectedVersion });
+  const warnings = versionWarnings(packageJson);
+  print({ ok: true, workflows: workflows.length, libVersion: expectedVersion, warnings });
+}
+
+function validateWorkflowSource(file: string, source: string, exportName: string) {
+  const path = relative(root, file);
+  const tokens = compilerTokens(source);
+  const functions = functionBodies(source, tokens);
+  for (const fn of functions) {
+    const { name, directive: directiveText, body: bodyText } = fn;
+    if (directiveText === "use step" && /\b(?:provider|agent)\s*\(/.test(bodyText)) {
+      const noRetry = new RegExp(`\\b${name}\\.maxRetries\\s*=\\s*0\\b`).test(source);
+      const retryableOnly = /catch\s*\([^)]*\)\s*\{[\s\S]*RetryableError[\s\S]*throw/.test(
+        bodyText,
+      );
+      if (!noRetry && !retryableOnly) {
+        throw new AppError(
+          "paid_step_retries",
+          `${path} paid step ${name} must set maxRetries = 0 or rethrow only RetryableError`,
+          2,
+        );
+      }
+    }
+    if (directiveText === "use workflow") {
+      const violations = ["Date.now", "Math.random", "fetch"].filter((call) =>
+        new RegExp(`\\b${call.replace(".", "\\.")}\\s*\\(`).test(bodyText),
+      );
+      if (violations.length) {
+        throw new AppError(
+          "nondeterministic_workflow",
+          `${path} workflow body calls ${[...new Set(violations)].join(", ")}`,
+          2,
+        );
+      }
+      if (!/\brunRows\s*\(/.test(bodyText) && !/\bupdateRun\s*\(/.test(bodyText)) {
+        throw new AppError(
+          "missing_terminal_bookkeeping",
+          `${path} must call runRows() or terminal updateRun()`,
+          2,
+        );
+      }
+    }
+  }
+  if (!functions.some((fn) => fn.name === exportName)) {
+    throw new AppError("invalid_export", `${path} must export ${exportName}`, 2);
+  }
+
+  let braceDepth = 0;
+  for (let index = 0; index < tokens.length; index += 1) {
+    const token = tokens[index];
+    if (token.kind === SyntaxKind.OpenBraceToken) braceDepth += 1;
+    if (token.kind === SyntaxKind.CloseBraceToken) braceDepth -= 1;
+    if (braceDepth !== 0 || token.kind !== SyntaxKind.OpenParenToken) continue;
+    const previous = tokens[index - 1];
+    if (!previous || previous.kind !== SyntaxKind.Identifier) continue;
+    if (tokens.slice(Math.max(0, index - 4), index).some((item) => item.kind === SyntaxKind.FunctionKeyword)) {
+      continue;
+    }
+    let rootIndex = index - 1;
+    while (
+      rootIndex >= 2 &&
+      tokens[rootIndex - 1].kind === SyntaxKind.DotToken &&
+      tokens[rootIndex - 2].kind === SyntaxKind.Identifier
+    ) {
+      rootIndex -= 2;
+    }
+    if (tokens[rootIndex].text !== "z") {
+      throw new AppError(
+        "invalid_module_scope",
+        `${path} executes ${tokens[rootIndex].text} at module scope`,
+        2,
+      );
+    }
+  }
+}
+
+async function validateTableSources() {
+  const directory = join(root, "db", "tables");
+  if (!existsSync(directory)) return;
+  for (const file of await walk(directory, (candidate) => candidate.endsWith(".ts"))) {
+    const source = await readFile(file, "utf8");
+    compilerTokens(source);
+    if (!/\bkey\s*:\s*[^,\n]+\.primaryKey\s*\(/.test(source)) {
+      throw new AppError(
+        "invalid_result_table",
+        `${relative(root, file)} table must declare key as the primary key`,
+        2,
+      );
+    }
+    if (!/\bupdatedAt\s*:\s*[^,\n]+\.notNull\s*\(/.test(source)) {
+      throw new AppError(
+        "invalid_result_table",
+        `${relative(root, file)} table must declare non-null updatedAt`,
+        2,
+      );
+    }
+  }
+}
+
+type CompilerToken = { kind: SyntaxKind; text: string; value: string; start: number; end: number };
+
+function compilerTokens(source: string): CompilerToken[] {
+  const scanner = createScanner(true, LanguageVariant.Standard, source);
+  const tokens: CompilerToken[] = [];
+  while (true) {
+    const kind = scanner.scan();
+    if (kind === SyntaxKind.EndOfFile) break;
+    tokens.push({
+      kind,
+      text: scanner.getTokenText(),
+      value: scanner.getTokenValue(),
+      start: scanner.getTokenStart(),
+      end: scanner.getTokenEnd(),
+    });
+  }
+  return tokens;
+}
+
+function functionBodies(source: string, tokens: CompilerToken[]) {
+  const bodies: { name: string; directive?: string; body: string }[] = [];
+  for (let index = 0; index < tokens.length; index += 1) {
+    if (tokens[index].kind !== SyntaxKind.FunctionKeyword) continue;
+    const name = tokens[index + 1];
+    if (!name || name.kind !== SyntaxKind.Identifier) continue;
+    const openIndex = tokens.findIndex(
+      (token, candidate) => candidate > index && token.kind === SyntaxKind.OpenBraceToken,
+    );
+    if (openIndex < 0) continue;
+    let depth = 0;
+    let closeIndex = -1;
+    for (let candidate = openIndex; candidate < tokens.length; candidate += 1) {
+      if (tokens[candidate].kind === SyntaxKind.OpenBraceToken) depth += 1;
+      if (tokens[candidate].kind === SyntaxKind.CloseBraceToken) depth -= 1;
+      if (depth === 0) {
+        closeIndex = candidate;
+        break;
+      }
+    }
+    if (closeIndex < 0) continue;
+    const first = tokens[openIndex + 1];
+    bodies.push({
+      name: name.text,
+      directive: first?.kind === SyntaxKind.StringLiteral ? first.value : undefined,
+      body: source.slice(tokens[openIndex].start, tokens[closeIndex].end),
+    });
+    index = closeIndex;
+  }
+  return bodies;
+}
+
+function versionWarnings(packageJson: any): string[] {
+  const expected = packageJson.gtm?.validatedAgainst ?? {};
+  const actual = {
+    workflow: packageJson.dependencies?.workflow,
+    nitro: packageJson.dependencies?.nitro,
+    drizzleKit: packageJson.devDependencies?.["drizzle-kit"],
+    node: process.versions.node.split(".")[0],
+  };
+  return Object.entries(expected).flatMap(([name, version]) =>
+    String(actual[name as keyof typeof actual]) === String(version)
+      ? []
+      : [`${name} validated against ${version}, installed ${actual[name as keyof typeof actual] ?? "missing"}`],
+  );
 }
 
 async function validateMigrationArtifacts() {
@@ -256,7 +455,7 @@ async function validateMigrationArtifacts() {
       2,
     );
   }
-  const tags = new Set(
+  const tags = new Set<string>(
     journal.entries.flatMap((entry: any) =>
       entry && typeof entry.tag === "string" ? [entry.tag] : [],
     ),
@@ -282,8 +481,19 @@ async function validateMigrationArtifacts() {
       );
     }
     const sql = await readFile(join(directory, file), "utf8");
+    const visibleSql = sql.replace(/\/\*[\s\S]*?\*\//g, " ").replace(/--[^\n]*/g, " ");
+    const destructive = visibleSql.match(
+      /\b(?:delete|update|rename|drop)\b|\bcreate\s+trigger\b/i,
+    );
+    if (destructive) {
+      throw new AppError(
+        "destructive_migration",
+        `${file} contains destructive SQL (${destructive[0].toUpperCase()})`,
+        2,
+      );
+    }
     const changesSchema = /\b(?:create|alter|drop)\s+(?:table|index|view|trigger)\b/i.test(
-      sql.replace(/\/\*[\s\S]*?\*\//g, " ").replace(/--[^\n]*/g, " "),
+      visibleSql,
     );
     if (changesSchema && !existsSync(join(directory, "meta", `${sequence}_snapshot.json`))) {
       throw new AppError(
@@ -334,7 +544,7 @@ async function request(url: URL, init: RequestInit) {
   if (response.ok) return payload as any;
   const code = payload?.error?.code ?? `http_${response.status}`;
   const exitCode = response.status === 401 ? 3 : response.status === 404 ? 6 : response.status === 429 ? 4 : 1;
-  throw new AppError(code, payload?.error?.message ?? response.statusText, exitCode);
+  throw new AppError(code, redact(payload?.error?.message ?? response.statusText), exitCode);
 }
 
 async function resolveOrigin(workflow: string | undefined, flags: Flags): Promise<string> {
@@ -378,16 +588,16 @@ async function workflowFiles() {
 }
 
 async function headeredFiles() {
-  const files = (await walk(join(root, "lib"), (file) => file.endsWith(".ts"))).concat([
-    join(root, "server", "api", "run", "[...workflow].ts"),
-    join(root, "server", "api", "runs", "[runId].get.ts"),
-    join(root, "server", "api", "runs", "[runId]", "cancel.post.ts"),
-    join(root, "server", "api", "approve", "[token].post.ts"),
+  const files = (await walk(join(root, "lib"), (file) => file.endsWith(".ts")))
+    .concat(await walk(join(root, "server", "api"), (file) => file.endsWith(".ts")))
+    .concat([
     join(root, "scripts", "gtm.ts"),
+    join(root, "scripts", "migrate-cloud.ts"),
+    join(root, "scripts", "verify-migrations.ts"),
     join(root, "drizzle.config.ts"),
     join(root, "nitro.config.ts"),
   ]);
-  return files;
+  return files.sort();
 }
 
 async function walk(directory: string, accept: (file: string) => boolean): Promise<string[]> {
@@ -404,30 +614,73 @@ function workflowPath(file: string) {
   return relative(join(root, "workflows"), file).slice(0, -3).split(sep).join("/");
 }
 
-function rowCount(body: unknown): number {
-  if (body && typeof body === "object" && Array.isArray((body as any).rows)) {
-    return (body as any).rows.length;
+async function loadWorkflow(file: string, body: unknown) {
+  let loaded: any;
+  try {
+    loaded = await import(`${pathToFileURL(file).href}?gtm-dry-run=${Date.now()}`);
+  } catch (caught) {
+    throw new AppError("invalid_workflow", `Cannot import ${relative(root, file)}: ${redact(caught)}`, 2);
   }
-  if (body && typeof body === "object") {
-    const arrays = Object.values(body).filter(Array.isArray) as unknown[][];
-    if (arrays.length === 1) return arrays[0].length;
-    if (arrays.length > 1) {
-      throw new AppError("ambiguous_rows", "Input has more than one top-level array.", 2);
+  if (!loaded.input?.safeParse) {
+    throw new AppError("invalid_workflow", `${relative(root, file)} must export a Zod input schema`, 2);
+  }
+  const parsed = loaded.input.safeParse(body);
+  if (!parsed.success) {
+    throw new AppError(
+      "invalid_input_schema",
+      parsed.error.issues
+        .map((issue: any) => `${issue.path.join(".") || "input"}: ${issue.message}`)
+        .join("; "),
+      2,
+    );
+  }
+  for (const name of ["MAX_ROWS", "COST_PER_ROW_USD", "MAX_SPEND_USD"]) {
+    if (!Number.isFinite(loaded[name])) {
+      throw new AppError("invalid_workflow", `${relative(root, file)} must export numeric ${name}`, 2);
     }
   }
-  return Array.isArray(body) ? body.length : 1;
+  return {
+    input: parsed.data,
+    maxRows: Number(loaded.MAX_ROWS),
+    costPerRowUsd: Number(loaded.COST_PER_ROW_USD),
+    maxSpendUsd: Number(loaded.MAX_SPEND_USD),
+  };
+}
+
+async function deploymentHead(workflow: string, origin: string): Promise<string | undefined> {
+  if (process.env.VERCEL_GIT_COMMIT_SHA) return process.env.VERCEL_GIT_COMMIT_SHA;
+  const source = await readFile(workflow, "utf8");
+  if (header(source, "Runs") !== "on Vercel") return undefined;
+  const packageJson = JSON.parse(await readFile(join(root, "package.json"), "utf8"));
+  const recorded = packageJson.gtm?.vercel?.url;
+  if (!recorded) return undefined;
+  const recordedOrigin = new URL(recorded.startsWith("http") ? recorded : `https://${recorded}`).origin;
+  if (new URL(origin).origin !== recordedOrigin) return undefined;
+
+  const status = await commandOutput("git", ["status", "--porcelain"]);
+  if (status.trim()) {
+    throw new AppError(
+      "deployment_workspace_dirty",
+      "Refusing production start because the workspace has uncommitted changes.",
+      2,
+    );
+  }
+  const head = (await commandOutput("git", ["rev-parse", "HEAD"])).trim();
+  const main = (await commandOutput("git", ["rev-parse", "origin/main"])).trim();
+  if (head !== main) {
+    throw new AppError(
+      "deployment_head_not_pushed",
+      "Refusing production start because HEAD is not the pushed origin/main commit.",
+      2,
+    );
+  }
+  return head;
 }
 
 function header(source: string, name: string) {
   const match = source.match(new RegExp(`^\\s*\\*\\s+${name}:\\s*(.+)$`, "m"));
   if (!match) throw new AppError("invalid_workflow", `Missing ${name}: header`, 2);
   return match[1].trim();
-}
-
-function exportedNumber(source: string, name: string) {
-  const match = source.match(new RegExp(`export\\s+const\\s+${name}\\s*=\\s*([0-9.]+)`));
-  if (!match) throw new AppError("invalid_workflow", `Missing numeric ${name}`, 2);
-  return Number(match[1]);
 }
 
 function authHeaders() {
@@ -460,7 +713,7 @@ function stringFlag(flags: Flags, name: string) {
 }
 
 function terminal(status: string) {
-  return ["completed", "failed", "cancelled"].includes(status);
+  return ["completed", "stopped", "timed_out", "failed", "cancelled"].includes(status);
 }
 
 async function command(executable: string, args: string[]) {
@@ -473,6 +726,22 @@ async function command(executable: string, args: string[]) {
       code === 0
         ? resolvePromise()
         : reject(new AppError("check_failed", stderr.slice(-2_000) || `${basename(executable)} failed`, 2)),
+    );
+  });
+}
+
+async function commandOutput(executable: string, args: string[]): Promise<string> {
+  return new Promise((resolvePromise, reject) => {
+    const child = spawn(executable, args, { cwd: root, stdio: ["ignore", "pipe", "pipe"] });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => (stdout += chunk));
+    child.stderr.on("data", (chunk) => (stderr += chunk));
+    child.on("error", reject);
+    child.on("close", (code) =>
+      code === 0
+        ? resolvePromise(stdout)
+        : reject(new AppError("git_check_failed", redact(stderr) || `${executable} failed`, 2)),
     );
   });
 }
@@ -496,7 +765,7 @@ function toMarkdown(rows: Record<string, unknown>[]) {
 }
 
 function print(value: unknown) {
-  process.stdout.write(`${JSON.stringify(value)}\n`);
+  process.stdout.write(`${JSON.stringify(redactValue(value))}\n`);
 }
 
 function delay(ms: number) {

--- a/skills/gtm-workflow/templates/scripts/migrate-cloud.ts
+++ b/skills/gtm-workflow/templates/scripts/migrate-cloud.ts
@@ -1,9 +1,7 @@
-// gtm-lib v9
-import { createHash } from "node:crypto";
+// gtm-lib v10
 import { spawn } from "node:child_process";
-import { readFile } from "node:fs/promises";
 import { join } from "node:path";
-import { createClient } from "@libsql/client";
+import { verifyMigrationLedger } from "../lib/migration-ledger";
 
 const root = process.cwd();
 const url = process.env.TURSO_DATABASE_URL?.trim();
@@ -17,7 +15,10 @@ if (!authToken) {
 }
 
 await runDrizzleMigration();
-await verifyMigrationLedger();
+const verified = await verifyMigrationLedger({ root, url, authToken });
+process.stdout.write(
+  `Verified ${verified} migration ledger entr${verified === 1 ? "y" : "ies"}.\n`,
+);
 
 async function runDrizzleMigration(): Promise<void> {
   const drizzleKit = join(root, "node_modules", "drizzle-kit", "bin.cjs");
@@ -33,38 +34,4 @@ async function runDrizzleMigration(): Promise<void> {
   if (exitCode !== 0) {
     throw new Error(`drizzle-kit migrate exited with status ${exitCode}`);
   }
-}
-
-async function verifyMigrationLedger(): Promise<void> {
-  const journal = JSON.parse(
-    await readFile(join(root, "drizzle", "meta", "_journal.json"), "utf8"),
-  ) as { entries?: { tag?: string }[] };
-  if (!Array.isArray(journal.entries)) {
-    throw new Error("drizzle/meta/_journal.json has no entries array");
-  }
-
-  const expected = new Map<string, string>();
-  for (const entry of journal.entries) {
-    if (!entry.tag) throw new Error("Drizzle journal entry has no tag");
-    const file = `drizzle/${entry.tag}.sql`;
-    const contents = await readFile(join(root, file));
-    expected.set(createHash("sha256").update(contents).digest("hex"), file);
-  }
-
-  const client = createClient({ url, authToken });
-  try {
-    const result = await client.execute("SELECT hash FROM __drizzle_migrations");
-    for (const row of result.rows) expected.delete(String(row.hash));
-  } finally {
-    client.close();
-  }
-
-  if (expected.size > 0) {
-    throw new Error(
-      `Migration ledger is missing: ${[...expected.values()].join(", ")}`,
-    );
-  }
-  process.stdout.write(
-    `Verified ${journal.entries.length} migration ledger entr${journal.entries.length === 1 ? "y" : "ies"}.\n`,
-  );
 }

--- a/skills/gtm-workflow/templates/scripts/verify-migrations.ts
+++ b/skills/gtm-workflow/templates/scripts/verify-migrations.ts
@@ -1,0 +1,14 @@
+// gtm-lib v10
+import { verifyMigrationLedger } from "../lib/migration-ledger";
+import { getDatabaseConfig } from "../lib/db-url";
+
+const root = process.cwd();
+const database = getDatabaseConfig();
+const verified = await verifyMigrationLedger({
+  root,
+  url: database.url,
+  authToken: database.authToken,
+});
+process.stdout.write(
+  `Verified ${verified} migration ledger entr${verified === 1 ? "y" : "ies"}.\n`,
+);

--- a/skills/gtm-workflow/templates/server/api/approve/[token].post.ts
+++ b/skills/gtm-workflow/templates/server/api/approve/[token].post.ts
@@ -1,48 +1,58 @@
-// gtm-lib v9
+// gtm-lib v10
 import { defineEventHandler } from "nitro/h3";
-import { resumeHook } from "workflow/api";
-import { HookNotFoundError } from "workflow/internal/errors";
-import { z } from "zod";
-
-const decision = z.object({
-  approved: z.boolean(),
-  comment: z.string().nullable().default(null),
-});
+import { HookNotFoundError } from "workflow/errors";
+import { approvalDecision, approvalHook } from "../../../lib/approve";
+import { getRunRow, updateRunPlain } from "../../../lib/db";
+import { redactValue } from "../../../lib/redact";
 
 export default defineEventHandler(async (event) => {
   const secret = process.env.GTM_RUN_SECRET;
   const authorization = event.req.headers.get("authorization");
   if (!secret || authorization !== `Bearer ${secret}`) {
-    return Response.json(
-      { error: { code: "unauthorized", message: "A valid bearer is required." } },
-      { status: 401 },
-    );
+    return error(401, "unauthorized", "A valid bearer is required.");
   }
   const token = event.context.params?.token;
-  if (!token) {
-    return Response.json(
-      { error: { code: "invalid_token", message: "approval token required" } },
-      { status: 400 },
-    );
+  if (!token) return error(400, "invalid_token", "approval token required");
+
+  const parsed = approvalDecision.safeParse(await event.req.json());
+  if (!parsed.success) {
+    return error(400, "invalid_decision", parsed.error.message);
   }
 
-  const parsed = decision.safeParse(await event.req.json());
-  if (!parsed.success) {
-    return Response.json(
-      { error: { code: "invalid_decision", message: parsed.error.message } },
-      { status: 400 },
-    );
+  const runKey = token.split(".")[1];
+  const row = runKey ? await getRunRow(runKey) : undefined;
+  const pending = row?.approval ? JSON.parse(row.approval) : null;
+  if (
+    !row ||
+    row.finishedAt !== null ||
+    row.status !== "waiting" ||
+    pending?.token !== token ||
+    pending?.resolved_at
+  ) {
+    return error(409, "approval_not_pending", "approval is no longer pending");
   }
+
   try {
-    await resumeHook(token, parsed.data);
+    await approvalHook.resume(token, parsed.data);
+    const resolved = redactValue({
+      ...pending,
+      ...parsed.data,
+      resolved_at: Date.now(),
+    });
+    await updateRunPlain(row.runKey, {
+      status: parsed.data.approved ? "running" : "stopped",
+      stopReason: parsed.data.approved ? null : "operator_denied",
+      approval: JSON.stringify(resolved),
+    });
     return Response.json({ approved: parsed.data.approved });
   } catch (caught) {
     if (HookNotFoundError.is(caught)) {
-      return Response.json(
-        { error: { code: "not_found", message: "approval is no longer pending" } },
-        { status: 404 },
-      );
+      return error(409, "approval_not_pending", "approval is no longer pending");
     }
     throw caught;
   }
 });
+
+function error(status: number, code: string, message: string) {
+  return Response.json({ error: { code, message } }, { status });
+}

--- a/skills/gtm-workflow/templates/server/api/deployment.get.ts
+++ b/skills/gtm-workflow/templates/server/api/deployment.get.ts
@@ -1,4 +1,4 @@
-// gtm-lib v9
+// gtm-lib v10
 import { defineEventHandler } from "nitro/h3";
 
 export default defineEventHandler(async (event) => {

--- a/skills/gtm-workflow/templates/server/api/run/[...workflow].ts
+++ b/skills/gtm-workflow/templates/server/api/run/[...workflow].ts
@@ -1,13 +1,15 @@
-// gtm-lib v9
+// gtm-lib v10
 import { createHash, randomBytes } from "node:crypto";
 import { defineEventHandler } from "nitro/h3";
 import { start } from "workflow/api";
 import {
   findLiveRun,
+  findScheduledRun,
   insertRun,
   reconcileRun,
   updateRunPlain,
 } from "../../../lib/db";
+import { redact } from "../../../lib/redact";
 
 export default defineEventHandler(async (event) => {
   const requestedMethod = event.req.method;
@@ -30,11 +32,14 @@ export default defineEventHandler(async (event) => {
 
   const expectedHead = event.req.headers.get("x-gtm-workspace-head");
   const deployedHead = process.env.VERCEL_GIT_COMMIT_SHA;
-  if (
-    method === "POST" &&
-    expectedHead !== null &&
-    (!deployedHead || expectedHead !== deployedHead)
-  ) {
+  if (method === "POST" && deployedHead && expectedHead === null) {
+    return error(
+      409,
+      "deployment_head_required",
+      "Production starts require the accepted workspace commit.",
+    );
+  }
+  if (method === "POST" && expectedHead !== null && expectedHead !== deployedHead) {
     return error(
       409,
       "deployment_not_ready",
@@ -60,6 +65,24 @@ export default defineEventHandler(async (event) => {
     return error(400, "invalid_checkpoint", "checkpoint must be a positive POST integer");
   }
 
+  const requestedDate = requestUrl.searchParams.get("scheduled-for");
+  if (requestedDate !== null && !/^\d{4}-\d{2}-\d{2}$/.test(requestedDate)) {
+    return error(400, "invalid_scheduled_for", "scheduled-for must be YYYY-MM-DD");
+  }
+  const scheduledFor =
+    method === "GET" ? new Date().toISOString().slice(0, 10) : requestedDate;
+  if (scheduledFor) {
+    const existing = await findScheduledRun(workflowPath, scheduledFor);
+    if (existing) {
+      return error(
+        409,
+        "already_ran_today",
+        `${basename} already has a run for ${scheduledFor}`,
+        { runKey: existing.runKey, runId: existing.runId, scheduledFor },
+      );
+    }
+  }
+
   const input = stableJson(body);
   const inputHash = createHash("sha256").update(input).digest("hex");
   const runKey = randomBytes(16).toString("hex");
@@ -73,6 +96,7 @@ export default defineEventHandler(async (event) => {
     inputHash,
     status: "running" as const,
     checkpoint,
+    scheduledFor,
     startedAt: Date.now(),
   };
 
@@ -81,6 +105,17 @@ export default defineEventHandler(async (event) => {
       await insertRun(row);
       break;
     } catch (caught) {
+      if (scheduledFor) {
+        const existing = await findScheduledRun(workflowPath, scheduledFor);
+        if (existing) {
+          return error(
+            409,
+            "already_ran_today",
+            `${basename} already has a run for ${scheduledFor}`,
+            { runKey: existing.runKey, runId: existing.runId, scheduledFor },
+          );
+        }
+      }
       const existing = await findLiveRun(workflowPath, inputHash);
       if (!existing) throw caught;
       const reconciled = await reconcileRun(existing.runKey);
@@ -88,29 +123,51 @@ export default defineEventHandler(async (event) => {
       return error(
         409,
         "run_in_progress",
-        `${basename} is already running as ${existing.runKey}; wait, or cancel it and run gtm runs get ${existing.runKey} to clear`,
+        `${basename} is already running as ${existing.runKey}; inspect it before retrying`,
         { runKey: existing.runKey, runId: existing.runId },
       );
     }
   }
 
-  const meta = { runKey, slug: basename, checkpoint };
+  const meta = { runKey, slug: basename, checkpoint, scheduledFor };
+  let run;
   try {
-    const run =
+    run =
       method === "GET"
-        ? await start({ workflowId }, [null, meta])
-        : await start({ workflowId }, [body, meta]);
-    await updateRunPlain(runKey, { runId: run.runId });
-    return Response.json({ runId: run.runId, runKey, workflow: workflowPath });
+        ? await start({ workflowId }, [null, meta], {
+            attributes: runAttributes(runKey, basename, deployedHead, checkpoint),
+          })
+        : await start({ workflowId }, [body, meta], {
+            attributes: runAttributes(runKey, basename, expectedHead, checkpoint),
+          });
   } catch (caught) {
     await updateRunPlain(runKey, {
       status: "failed",
-      error: message(caught),
+      error: redact(caught),
       finishedAt: Date.now(),
     });
     throw caught;
   }
+
+  // The workflow's first library step writes the same run id. If this route
+  // write fails after start(), the live row remains closed until that step does it.
+  await updateRunPlain(runKey, { runId: run.runId }).catch(() => undefined);
+  return Response.json({ runId: run.runId, runKey, workflow: workflowPath });
 });
+
+function runAttributes(
+  runKey: string,
+  workflow: string,
+  workspaceHead: string | null | undefined,
+  checkpoint: number | null,
+) {
+  return {
+    gtmRunKey: runKey,
+    workflow,
+    workspaceHead: workspaceHead ?? "local",
+    checkpoint: checkpoint === null ? "none" : String(checkpoint),
+  };
+}
 
 function stableJson(value: unknown): string {
   if (Array.isArray(value)) return `[${value.map(stableJson).join(",")}]`;
@@ -130,8 +187,4 @@ function error(
   extra: Record<string, unknown> = {},
 ) {
   return Response.json({ error: { code, message, ...extra } }, { status });
-}
-
-function message(value: unknown): string {
-  return value instanceof Error ? value.message : String(value);
 }

--- a/skills/gtm-workflow/templates/server/api/runs/[runId].get.ts
+++ b/skills/gtm-workflow/templates/server/api/runs/[runId].get.ts
@@ -1,8 +1,9 @@
-// gtm-lib v9
+// gtm-lib v10
 import { defineEventHandler } from "nitro/h3";
 import { getRun } from "workflow/api";
 import { WorkflowRunFailedError } from "workflow/errors";
-import { getRunRow, reconcileRun } from "../../../lib/db";
+import { getRunCostSources, getRunRow, reconcileRun } from "../../../lib/db";
+import { redact, redactValue } from "../../../lib/redact";
 
 export default defineEventHandler(async (event) => {
   const secret = process.env.GTM_RUN_SECRET;
@@ -29,7 +30,7 @@ export default defineEventHandler(async (event) => {
       { status: 404 },
     );
   }
-  if (["running", "waiting"].includes(row.status)) {
+  if (["running", "waiting", "cancelling"].includes(row.status)) {
     row = await reconcileRun(row.runKey);
   }
 
@@ -37,9 +38,12 @@ export default defineEventHandler(async (event) => {
     ...row,
     input: JSON.parse(row.input),
     approval: row.approval ? JSON.parse(row.approval) : null,
+    remaining_keys: row.remainingKeys ? JSON.parse(row.remainingKeys) : [],
     webhook_url: row.webhookUrl,
+    trigger_token: row.triggerToken,
+    cost_sources: await getRunCostSources(row.runKey),
   };
-  if (row.status === "completed" && row.runId) {
+  if (["completed", "stopped", "timed_out"].includes(row.status) && row.runId) {
     const run = getRun(row.runId);
     if (await run.exists) response.result = await run.returnValue;
   } else if (row.status === "failed" && row.runId) {
@@ -51,15 +55,15 @@ export default defineEventHandler(async (event) => {
         response.error = {
           message: WorkflowRunFailedError.is(caught)
             ? caught.cause instanceof Error
-              ? caught.cause.message
-              : String(caught.cause)
+              ? redact(caught.cause.message)
+              : redact(caught.cause)
             : caught instanceof Error
-              ? caught.message
-              : String(caught),
+              ? redact(caught.message)
+              : redact(caught),
         };
       }
     }
   }
 
-  return Response.json(response);
+  return Response.json(redactValue(response));
 });

--- a/skills/gtm-workflow/templates/server/api/runs/[runId]/cancel.post.ts
+++ b/skills/gtm-workflow/templates/server/api/runs/[runId]/cancel.post.ts
@@ -1,8 +1,11 @@
-// gtm-lib v9
+// gtm-lib v10
 import { defineEventHandler } from "nitro/h3";
 import { getRun } from "workflow/api";
+import { HookNotFoundError } from "workflow/errors";
 import { z } from "zod";
+import { cancellationHook } from "../../../../lib/approve";
 import { getRunRow, reconcileRun, updateRunPlain } from "../../../../lib/db";
+import { redactValue } from "../../../../lib/redact";
 
 const decision = z.object({
   reason: z.string().max(500).nullable().default(null),
@@ -26,7 +29,7 @@ export default defineEventHandler(async (event) => {
 
   let row = await getRunRow(identifier);
   if (!row) return error(404, "not_found", `Unknown run ${identifier}`);
-  if (["running", "waiting"].includes(row.status)) {
+  if (["running", "waiting", "cancelling"].includes(row.status)) {
     row = await reconcileRun(row.runKey);
   }
   if (row.finishedAt !== null || !["running", "waiting"].includes(row.status)) {
@@ -36,27 +39,36 @@ export default defineEventHandler(async (event) => {
     });
   }
 
+  await updateRunPlain(row.runKey, {
+    status: "cancelling",
+    stopReason: parsed.data.reason ?? "operator_cancelled",
+    cancelRequestedAt: Date.now(),
+  });
+  const resumeCancellation = cancellationHook
+    .resume(`${row.workflow}.${row.runKey}.cancel`, {
+      reason: parsed.data.reason,
+    })
+    .catch((caught) => {
+      if (!HookNotFoundError.is(caught)) throw caught;
+    });
+  let cancelRun: Promise<unknown> = Promise.resolve();
   if (row.runId) {
     const run = getRun(row.runId);
     if (await run.exists) {
-      await run.cancel(
+      cancelRun = run.cancel(
         parsed.data.reason === null ? undefined : { cancelReason: parsed.data.reason },
       );
     }
   }
-  await updateRunPlain(row.runKey, {
-    status: "cancelled",
-    ...(parsed.data.reason === null ? {} : { error: `cancelled: ${parsed.data.reason}` }),
-    finishedAt: Date.now(),
-  });
+  await Promise.all([resumeCancellation, cancelRun]);
 
   const cancelled = (await getRunRow(row.runKey))!;
-  return Response.json({
+  return Response.json(redactValue({
     ...cancelled,
     input: JSON.parse(cancelled.input),
     approval: cancelled.approval ? JSON.parse(cancelled.approval) : null,
     webhook_url: cancelled.webhookUrl,
-  });
+  }));
 });
 
 function error(

--- a/skills/gtm-workflow/templates/server/api/runs/[runId]/trigger.post.ts
+++ b/skills/gtm-workflow/templates/server/api/runs/[runId]/trigger.post.ts
@@ -1,0 +1,40 @@
+// gtm-lib v10
+import { defineEventHandler } from "nitro/h3";
+import { HookNotFoundError } from "workflow/errors";
+import { triggerHook } from "../../../../lib/approve";
+import { getRunRow, updateRunPlain } from "../../../../lib/db";
+
+export default defineEventHandler(async (event) => {
+  const secret = process.env.GTM_RUN_SECRET;
+  const authorization = event.req.headers.get("authorization");
+  if (!secret || authorization !== `Bearer ${secret}`) {
+    return error(401, "unauthorized", "A valid bearer is required.");
+  }
+  const identifier = event.context.params?.runId;
+  if (!identifier) return error(400, "invalid_run", "run id or run key required");
+
+  const row = await getRunRow(identifier);
+  if (
+    !row ||
+    row.finishedAt !== null ||
+    row.status !== "waiting" ||
+    !row.triggerToken
+  ) {
+    return error(409, "trigger_not_pending", "trigger is no longer pending");
+  }
+
+  try {
+    await triggerHook.resume(row.triggerToken, await event.req.json());
+    await updateRunPlain(row.runKey, { status: "running", triggerToken: null });
+    return Response.json({ accepted: true, runKey: row.runKey });
+  } catch (caught) {
+    if (HookNotFoundError.is(caught)) {
+      return error(409, "trigger_not_pending", "trigger is no longer pending");
+    }
+    throw caught;
+  }
+});
+
+function error(status: number, code: string, message: string) {
+  return Response.json({ error: { code, message } }, { status });
+}


### PR DESCRIPTION
## Summary

- Completes A1-A11: read-only cloud inspection, enforceable model tool isolation, cancellation-safe duplicate protection, workflow self-registration, context-aware model caching, defensive redaction, pre-call paid ledgers, command authorization, public typed approval hooks, safe local recovery, and mandatory production commit proof.
- Completes B1-B14: `runRows`, compiler-backed house-rule checks, managed-file hashes, honest terminal states, expand-and-contract migration policy, deterministic lifecycle coverage, run attributes and failure identity, documented platform limits, scheduled-date deduplication, held provider runs, merge-safe upserts, authorized triggers, and schema-validating dry runs.
- Ships the v10 fixed-table migration, local migration-ledger verifier, command permission hook, updated host contract, and corrected operator references.

## Verification

- `node --test evals/gtm-workflow/scripts/test-templates.mjs` — passes the end-to-end deterministic contract, including every new guard and lifecycle path.
- `npm run gtm -- check` in the shipped template — passes at lib version 10 with expected host Node warning because the template remains validated against Node 22.
- `python3 .../skill-creator/scripts/quick_validate.py skills/gtm-workflow` — skill is valid.
- `git diff --check` and JSON syntax checks pass.

Fixes #43