### PR TITLE
Make workflow guarantees and releases legible

### DIFF
--- a/.github/workflows/skill-compatibility.yml
+++ b/.github/workflows/skill-compatibility.yml
@@ -1,0 +1,28 @@
+name: Skill compatibility
+
+on:
+  pull_request:
+    paths:
+      - "skills/**"
+      - "scripts/check_skill_compatibility.py"
+      - ".github/workflows/skill-compatibility.yml"
+  push:
+    branches: [main]
+    paths:
+      - "skills/**"
+      - "scripts/check_skill_compatibility.py"
+      - ".github/workflows/skill-compatibility.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  offline-loaders:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - run: python3 scripts/check_skill_compatibility.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,27 @@
+# Changelog
+
+## gtm-lib v10, 2026-08-28
+
+- Cloud inspection now requires a read-only credential and rejects data-changing statements, including writes hidden behind a common table expression.
+- Untrusted workflow content reaches only model backends that can disable tools. Accepted ICP and persona content now participates in the model cache key.
+- Cancellation keeps the duplicate-run guard closed until the runtime confirms the run stopped. A run can also register its own runtime ID after a route interruption.
+- Error text is redacted before it reaches ledgers, run records, route responses, or command output.
+- The paid-call ledger opens a pending entry before a request. It distinguishes reported, fixed, and projected cost, records zero-cost pre-call failures, and reconciles abandoned calls.
+- Approval hooks are single-use, local restart recovery does not repeat active paid work, and spend or mutation commands require a human gate.
+- Production starts require the exact accepted workspace commit. Missing, dirty, unpushed, or mismatched commits stop before a real run.
+- Shared row execution now owns spend caps, checkpoint behavior, per-row failures, honest terminal states, remaining keys, and final bookkeeping.
+
+## gtm-lib v9, 2026-08-27
+
+- Preserved original provider responses for cache reparsing.
+- Restored the local workflow runtime and made the paid-call ledger authoritative for run totals.
+
+## Upgrade notes for older projects
+
+| Installed library | User-visible reason to upgrade to v10 |
+| --- | --- |
+| v2 | No fixed workflow schema or committed migration path |
+| v5 | No supported run cancellation |
+| v6 | Web research evidence can be separated from the structured answer that needs it |
+| v8 | Cached provider responses cannot be reparsed from the original payload, and run totals can diverge from the ledger |
+| v9 | Read-only inspection, tool isolation, duplicate-run protection, context-aware caching, redaction, cost attribution, approval reuse, restart safety, and exact-commit starts are incomplete |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,30 @@
+# Contributing
+
+Contributions should preserve one shared workspace contract and the authority boundaries in each skill. Open an issue before changing a public contract, persistent file shape, approval gate, or workflow-library version.
+
+## Hard rejects
+
+A contribution is rejected if it includes any of the following:
+
+- A hardcoded secret, example credential that looks usable, or skill text that asks the user to paste a credential into a prompt or conversation.
+- Instructions that send workspace data to an undeclared destination or fetch code for execution at runtime.
+- Prompt-injection patterns that treat row content, fetched content, tool output, or another remote source as instructions or authority.
+- A network endpoint without a named owner, purpose, authentication boundary, input contract, output contract, and failure behavior.
+- A bulk, destructive, paid, or externally visible action without an explicit human gate that states the exact scope and effect.
+- A third-party product name in a skill file. State the required capability and keep integration-specific facts in the narrowest permitted adapter or reference.
+
+## Vendor swap test
+
+For every vendor mention outside a skill file, replace the vendor mentally with another provider of the same capability. The skill's trigger, procedure, approvals, and outputs must still make sense. If they do not, rewrite the rule around the capability or move the fact into the adapter-specific documentation that owns it.
+
+## Pull request checklist
+
+- Keep the change inside one declared scope and update the public contract when reads, writes, outputs, approvals, persistence, or handoffs change.
+- Add or update deterministic checks for changed behavior. Tests must not use live credentials, paid calls, or production endpoints.
+- Update [VERSIONS.md](VERSIONS.md) and [CHANGELOG.md](CHANGELOG.md) when behavior changes. A workflow-library bump also requires the release tag described in `VERSIONS.md`.
+- Run `python3 scripts/check_repo_layout.py` and `python3 scripts/check_skill_compatibility.py`. When workflow files change, also run `node --test evals/gtm-workflow/scripts/test-templates.mjs`.
+- Review the staged diff for secret values, unrelated files, remote-code execution, and missing human gates.
+
+## Security reports
+
+Follow [SECURITY.md](SECURITY.md) for vulnerabilities. Do not publish an exploitable report before a fix is available.

--- a/README.md
+++ b/README.md
@@ -1,16 +1,50 @@
 <p align="center"><img src="https://img.shields.io/badge/GTM%20Skills-Open%20source%20skills%20for%20GTM-2ea44f?style=flat-square&labelColor=24292f" alt="GTM Skills: open source skills for GTM" /></p>
 
-<h3 align="center">Build and maintain a shared GTM workspace</h3>
+<h3 align="center">Own the GTM data, the spend, and the code that runs</h3>
 
-<p align="center">GTM Skills gives your team four open source Lifecycle SOPs for maintaining one Git-backed GTM workspace, its ICPs and personas, and the reusable workflows they support.</p>
+<p align="center">GTM Skills keeps accepted organization facts, market definitions, buyer definitions, workflow code, and workflow results under one contract.</p>
+
+## Four guarantees you can inspect
+
+1. **Results land in a typed table you own.** Each workflow declares its result table and commits every schema change as a migration. Query business rows and the paid-call ledger with the same read-only command.
+2. **Every paid call is cached and costed.** Provider and model calls pass through one content-addressed cache and write one per-run ledger entry. An unchanged rerun records `cache_hit` at `$0`.
+3. **The preview costs nothing, then the real run stops after three rows.** The dry run validates input, rows, stages, projected cost, and caps without calling a paid service. The first accepted run saves three rows and pauses that same run for inspection.
+4. **Production runs the reviewed commit.** A production start waits for the deployed commit to match the accepted workspace commit and refuses a missing or different commit.
+
+For an `account-scoring` workflow whose `account_scores.key` is the company domain, this command joins owned result rows to the latest run's paid-call ledger. It has no table or workflow placeholders:
+
+```sh
+npm run gtm -- query --sql "
+SELECT scores.key AS domain, calls.status, calls.cost_usd
+FROM account_scores AS scores
+JOIN enrichment_cache AS cached
+  ON json_extract(cached.inputs, '$.domain') = scores.key
+JOIN enrichment_runs AS calls
+  ON calls.provider = cached.provider
+ AND calls.endpoint = cached.endpoint
+ AND calls.inputs_hash = cached.inputs_hash
+WHERE calls.run_key = (
+  SELECT run_key
+  FROM workflow_runs
+  WHERE workflow = 'account-scoring'
+  ORDER BY started_at DESC
+  LIMIT 1
+)
+ORDER BY scores.key
+" --format markdown
+```
+
+An unchanged rerun produces ledger rows like this:
+
+| domain | status | cost_usd |
+| --- | --- | ---: |
+| northstar.example | cache_hit | 0 |
 
 <p align="center"><img src="assets/gtm-skills-flow.svg" width="88%" alt="GTM Skills turns a shared GTM workspace into grounded ICPs, personas, and workflows" /></p>
 
 <p align="center"><a href="https://github.com/eliasstravik/gtm-skills/blob/main/docs/getting-started.md"><img src="assets/buttons/install-gtm-skills.svg" alt="Install GTM Skills" /></a>&nbsp;&nbsp;<a href="https://cal.com/stravik/demo?projects=GTM%20Skills" target="_blank" rel="noopener noreferrer"><img src="assets/buttons/book-a-demo.svg" alt="Book a demo" /></a></p>
 
-<p align="center"><sub>✓&nbsp;100%&nbsp;free&nbsp;and&nbsp;open&nbsp;source &nbsp; ✓&nbsp;Four&nbsp;GTM&nbsp;skills,&nbsp;one&nbsp;install &nbsp; ✓&nbsp;Git-backed&nbsp;shared&nbsp;context</sub></p>
-
-<p align="center"><small>⭐ Used by top GTM teams</small></p>
+<p align="center"><sub>✓&nbsp;100%&nbsp;free&nbsp;and&nbsp;open&nbsp;source &nbsp; ✓&nbsp;One&nbsp;shared&nbsp;workspace &nbsp; ✓&nbsp;Typed&nbsp;results&nbsp;and&nbsp;costs</sub></p>
 
 <br />
 
@@ -18,51 +52,44 @@
 
 The GTM workspace records durable facts about the business and its team. ICPs define the companies each organization serves, personas define the buyers and stakeholders it needs to understand, and saved workflows turn that context into repeatable work. Every durable change is previewed in full, accepted explicitly, and saved to history.
 
-## Choose between repeated prompts, disconnected templates, custom agents, or one coherent foundation
+## Compare concrete behavior
 
 | | **GTM Skills** | Repeated prompts | Standalone templates | Custom agents |
 |---|:---:|:---:|:---:|:---:|
-| **Four ready-made GTM skills** | ✅ | ❌ | ❌ | ❌ |
-| **Shared Git-backed GTM workspace** | ✅ | ❌ | ❌ | ❌ |
-| **Organization lifecycle management** | ✅ | ❌ | ❌ | ❌ |
-| **ICP and persona lifecycle management** | ✅ | ❌ | ❌ | ❌ |
-| **Local and Vercel workflow lifecycle management** | ✅ | ❌ | ❌ | ❌ |
-| **Typed workflow result tables and migrations** | ✅ | ❌ | ❌ | ❌ |
-| **Dry runs, checkpoints, approvals, schedules, and webhooks** | ✅ | ❌ | ❌ | ❌ |
-| **Cached provider and model calls with a cost ledger** | ✅ | ❌ | ❌ | ❌ |
-| **Node-local organization support** | ✅ | ❌ | ❌ | ❌ |
-| **Review-before-write workflows** | ✅ | ❌ | ❌ | ❌ |
+| **Accepted facts and definitions live in one Git repository** | ✅ | ❌ | ❌ | ❌ |
+| **Root and nested organizations own separate ICP and persona files** | ✅ | ❌ | ❌ | ❌ |
+| **The agent previews complete durable changes before writing** | ✅ | ❌ | ❌ | ❌ |
+| **Every result table has types, a stable key, and committed migrations** | ✅ | ❌ | ❌ | ❌ |
+| **Every paid call passes through one content-addressed cache** | ✅ | ❌ | ❌ | ❌ |
+| **Every paid call writes status and cost to a per-run ledger** | ✅ | ❌ | ❌ | ❌ |
+| **A dry run validates input and caps without paid calls** | ✅ | ❌ | ❌ | ❌ |
+| **The first real run saves three rows before pausing for review** | ✅ | ❌ | ❌ | ❌ |
+| **Production refuses to run a commit other than the accepted commit** | ✅ | ❌ | ❌ | ❌ |
+| **The same workflow file runs locally or in a hosted deployment** | ✅ | ❌ | ❌ | ❌ |
 
 Keep durable GTM knowledge and reusable automations in one repository. Each SOP reads only the artifacts visible to the selected organization node and preserves accepted durable changes in history.
 
-## Organize the business. Define the market. Describe the buyer. Run the work.
+## How the four skills fit together
 
-### 🏗️ Build the shared GTM workspace
+The four skills are one chain of ownership, not four disconnected prompts. They resolve the same organization node, use the same review-before-write rule, and save accepted durable changes to the same Git history.
 
-Create or import an organization repository, add members and recursively nested suborganizations, update stored facts, and repair structural or Git problems.
+| Skill | Owns | Hands off |
+| --- | --- | --- |
+| `gtm-workspace` | Organization structure, members, repository health, and connections | The selected organization node and its visible files |
+| `gtm-icp` | The companies that node serves, including disqualifiers and uncertainty | An accepted market definition at a stable path |
+| `gtm-persona` | The buyers and stakeholders that node needs to understand | An accepted buyer definition at a stable path |
+| `gtm-workflow` | Typed workflow code, migrations, runs, results, cache entries, and costs | Database-backed outcomes tied to the accepted workspace context |
 
-### 📈 Define ideal customer profiles
-
-Create, refine, delete, or doctor the ICPs that each organization or business unit owns, without routing into persona or account-workflow changes.
-
-### 👥 Define buyer and stakeholder personas
-
-Create, refine, delete, or doctor personas with clear responsibilities, influence, authority boundaries, disqualifiers, and open questions, without routing into ICP or lead-workflow changes.
-
-### ⚙️ Build and run reusable GTM workflows
-
-Create, update, inspect, delete, or run a saved workflow. Each workflow declares a typed result table, commits its database migrations, and upserts rows by a stable key. The same TypeScript file runs on your computer with a local SQLite database or on Vercel with Turso.
-
-Before a real run, the agent reports rows, stages, projected cost, and caps without calling a provider or model. A checkpoint pauses the real run after the first saved rows so you can inspect them in Drizzle Studio and approve the rest of the same run. Provider and model calls share a cache and cost ledger, so unchanged reruns reuse prior results. Workflows can also wait for approval, run on a schedule, or resume from a per-run webhook.
+Project records: [versions and compatibility](VERSIONS.md) · [changelog](CHANGELOG.md) · [security policy](SECURITY.md) · [contribution rules](CONTRIBUTING.md)
 
 ## Build your GTM foundation in four steps
 
 <table>
 <tr>
-<td align="center" valign="top" width="25%"><h3>1️⃣</h3><b>Install GTM Skills</b><br /><sub>Run <code>npx skills add eliasstravik/gtm-skills -g</code> to install all four skills.</sub></td>
-<td align="center" valign="top" width="25%"><h3>2️⃣</h3><b>Build your GTM workspace</b><br /><sub>Run <code>/gtm-workspace</code> to create or import the organization repository and add the members and business units it owns.</sub></td>
-<td align="center" valign="top" width="25%"><h3>3️⃣</h3><b>Define the market and buyer</b><br /><sub>Run <code>/gtm-icp</code> and <code>/gtm-persona</code> to create the definitions each organization needs.</sub></td>
-<td align="center" valign="top" width="25%"><h3>4️⃣</h3><b>Build your first workflow</b><br /><sub>Run <code>/gtm-workflow</code>, declare its table and caps, review a zero-spend dry run, then inspect the first saved rows at a checkpoint.</sub></td>
+<td align="center" valign="top" width="25%"><h3>1</h3><b>Install GTM Skills</b><br /><sub>Run <code>npx skills add eliasstravik/gtm-skills -g</code> to install all four skills.</sub></td>
+<td align="center" valign="top" width="25%"><h3>2</h3><b>Build your GTM workspace</b><br /><sub>Run <code>/gtm-workspace</code> to create or import the organization repository and add the members and business units it owns.</sub></td>
+<td align="center" valign="top" width="25%"><h3>3</h3><b>Define the market and buyer</b><br /><sub>Run <code>/gtm-icp</code> and <code>/gtm-persona</code> to create the definitions each organization needs.</sub></td>
+<td align="center" valign="top" width="25%"><h3>4</h3><b>Build your first workflow</b><br /><sub>Run <code>/gtm-workflow</code>, declare its table and caps, review a zero-spend dry run, then inspect the first saved rows at a checkpoint.</sub></td>
 </tr>
 </table>
 
@@ -81,9 +108,9 @@ Before a real run, the agent reports rows, stages, projected cost, and caps with
 
 ## Get your questions answered
 
-### Do I need to know how to code?
+### Do I need to write the workflow code myself?
 
-No code is required to run the guided skills. You need `npx`, an AI agent that loads installed skills, and Git for the GTM workspace repository.
+No. The agent writes the workflow code and migrations. You review the complete tracked diff, the zero-spend dry run, and the first three saved rows. You need `npx`, an AI agent that loads installed skills, and Git for the GTM workspace repository.
 
 ### What gets installed?
 
@@ -111,6 +138,4 @@ GTM Skills is free, open source, and MIT licensed. Your AI or model provider may
 
 <p align="center"><a href="https://github.com/eliasstravik/gtm-skills/blob/main/docs/getting-started.md"><img src="assets/buttons/install-gtm-skills.svg" alt="Install GTM Skills" /></a>&nbsp;&nbsp;<a href="https://cal.com/stravik/demo?projects=GTM%20Skills" target="_blank" rel="noopener noreferrer"><img src="assets/buttons/book-a-demo.svg" alt="Book a demo" /></a></p>
 
-<p align="center"><sub>✓&nbsp;100%&nbsp;free&nbsp;and&nbsp;open&nbsp;source &nbsp; ✓&nbsp;Four&nbsp;GTM&nbsp;skills,&nbsp;one&nbsp;install &nbsp; ✓&nbsp;Git-backed&nbsp;shared&nbsp;context</sub></p>
-
-<p align="center"><small>⭐ Used by top GTM teams</small></p>
+<p align="center"><sub>✓&nbsp;100%&nbsp;free&nbsp;and&nbsp;open&nbsp;source &nbsp; ✓&nbsp;One&nbsp;shared&nbsp;workspace &nbsp; ✓&nbsp;Typed&nbsp;results&nbsp;and&nbsp;costs</sub></p>

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,29 @@
+# Security policy
+
+## Report a vulnerability
+
+Email `elias@eliasstravik.com` with the affected skill or file, the impact, reproduction steps, and any suggested mitigation. Do not open a public issue for an unpatched vulnerability or include live credentials in the report.
+
+## Secret handling
+
+Secrets enter through ignored environment files, shell input, or host-brokered headers. They do not belong in prompts, conversations, tracked files, workflow step input or output, cache inputs, ledgers, comments, or command output.
+
+Hosted mode keeps production run credentials, database write credentials, and other write capabilities in the host. The model receives only the bounded access needed to author, validate, dry-run, and inspect. It cannot start a real hosted run without the host's separate approval-gated control.
+
+If a credential appears in a conversation or tracked file, treat it as compromised. Revoke or rotate it, then store the replacement through the environment.
+
+## Local model trust boundary
+
+A local model backend runs with the operating-system access granted to its host process. Only a backend that enforces `tools: "none"` may receive untrusted row or provider content. The workflow stops before spawning a backend that cannot enforce that restriction unless the operator explicitly accepts host-default tool access for trusted input.
+
+Local environment isolation remains the operator's responsibility. Keep workflow credentials in the ignored environment files named by the workflow contract, restrict their file permissions, and review any backend-specific access before a real run.
+
+## Defensive redaction
+
+The v10 workflow library redacts error text before it reaches the paid-call ledger, run rows, route responses, or command output. It removes URL query strings, bearer values, sensitive assignments such as keys and passwords, and values matching non-empty environment variables whose names end in `_KEY`, `_TOKEN`, or `_SECRET`. It limits retained error text to 500 characters.
+
+Redaction is a fallback, not a storage mechanism for secrets. Adapters should throw short errors without request URLs or credentials, and callers should keep secret values out of workflow data from the start.
+
+## Supported versions
+
+The current skill and workflow-library versions are listed in [VERSIONS.md](VERSIONS.md). Security fixes target the current release. Upgrade older workflow projects through the skill's reviewed recopy and migration path.

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,0 +1,28 @@
+# Versions and compatibility
+
+This table is the public version record for the installable skills. Version `1.0.0` is the first tracked public-contract version for each skill. Earlier behavior remains visible in Git history.
+
+| Skill | Skill version | Last behavior change | Purpose | Shipped library | Exercised loaders | Checked |
+| --- | --- | --- | --- | --- | --- | --- |
+| `gtm-workspace` | 1.0.0 | 2026-08-24 | Creates, imports, maintains, and repairs the shared organization workspace | None | Shared `.agents/skills` loader; project `.claude/skills` loader | 2026-08-28 |
+| `gtm-icp` | 1.0.0 | 2026-08-13 | Owns node-local ideal customer profile creation, revision, deletion, and repair | None | Shared `.agents/skills` loader; project `.claude/skills` loader | 2026-08-28 |
+| `gtm-persona` | 1.0.0 | 2026-08-13 | Owns node-local buyer and stakeholder persona creation, revision, deletion, and repair | None | Shared `.agents/skills` loader; project `.claude/skills` loader | 2026-08-28 |
+| `gtm-workflow` | 1.0.0 | 2026-08-28 | Authors and runs typed, migrated workflows with cache, cost, approval, and deployment controls | `gtm-lib` v10 | Shared `.agents/skills` loader; project `.claude/skills` loader | 2026-08-28 |
+
+The offline compatibility check copies all four skills into both loader directory shapes, parses every `SKILL.md`, validates the common Contract fields, and resolves each local reference. Run it with:
+
+```sh
+python3 scripts/check_skill_compatibility.py
+```
+
+## Release tags
+
+The current workflow library release is `gtm-lib-v10`. The tag points to the first reviewed `main` commit that contains the complete v10 library and its migration.
+
+For every future workflow-library bump:
+
+1. Update every managed header, content hash, migration, workflow contract, this table, and [CHANGELOG.md](CHANGELOG.md) in the reviewed change.
+2. Merge the change to `main`.
+3. Create the annotated tag `gtm-lib-v<version>` on that merge commit and push the tag.
+
+Skill versions change only when the corresponding `SKILL.md` public behavior changes. Documentation corrections that do not change reads, writes, outputs, approvals, persistence, or handoffs do not require a skill-version bump.

--- a/scripts/check_skill_compatibility.py
+++ b/scripts/check_skill_compatibility.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Check installable skill contracts in the two supported loader shapes."""
+
+from __future__ import annotations
+
+import re
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+from urllib.parse import unquote, urlsplit
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SKILLS_ROOT = REPO_ROOT / "skills"
+LOADER_ROOTS = (Path(".agents/skills"), Path(".claude/skills"))
+CONTRACT_FIELDS = ("Reads", "Writes", "Outputs", "Approval", "Persists", "Handoff")
+FRONTMATTER = re.compile(r"\A---\n(?P<body>.*?)\n---\n", re.DOTALL)
+FIELD = re.compile(r"^(?P<key>[A-Za-z][A-Za-z0-9_-]*):\s*(?P<value>.+?)\s*$")
+LINK = re.compile(r"!?\[[^\]]*\]\((?P<target>[^)]+)\)")
+
+
+def parse_frontmatter(skill_md: Path, errors: list[str]) -> dict[str, str]:
+    text = skill_md.read_text()
+    match = FRONTMATTER.match(text)
+    if not match:
+        errors.append(f"{skill_md}: missing or malformed frontmatter")
+        return {}
+
+    fields: dict[str, str] = {}
+    for line in match.group("body").splitlines():
+        parsed = FIELD.match(line)
+        if parsed:
+            fields[parsed.group("key")] = parsed.group("value").strip("'\"")
+    if not fields.get("name"):
+        errors.append(f"{skill_md}: frontmatter has no name")
+    if not fields.get("description"):
+        errors.append(f"{skill_md}: frontmatter has no description")
+    return fields
+
+
+def check_contract(skill_md: Path, errors: list[str]) -> None:
+    text = skill_md.read_text()
+    start = text.find("**Contract**")
+    end = text.find("\n## Inputs")
+    if start == -1 or end == -1 or start > end:
+        errors.append(f"{skill_md}: Contract block must appear in Scope before Inputs")
+        return
+
+    block = text[start:end]
+    found = tuple(
+        match.group(1)
+        for line in block.splitlines()
+        if (match := re.match(r"^\|\s*([^|]+?)\s*\|", line))
+        and match.group(1) not in {"Field", "---"}
+    )
+    if found != CONTRACT_FIELDS:
+        errors.append(
+            f"{skill_md}: Contract fields are {found!r}; expected {CONTRACT_FIELDS!r}"
+        )
+
+
+def check_links(skill_md: Path, errors: list[str]) -> None:
+    for match in LINK.finditer(skill_md.read_text()):
+        raw_target = match.group("target").strip()
+        if raw_target.startswith("<") and raw_target.endswith(">"):
+            raw_target = raw_target[1:-1]
+        target = raw_target.split(maxsplit=1)[0]
+        parsed = urlsplit(target)
+        if parsed.scheme or parsed.netloc or target.startswith("#"):
+            continue
+        relative = unquote(parsed.path)
+        if relative and not (skill_md.parent / relative).exists():
+            errors.append(f"{skill_md}: unresolved reference {target}")
+
+
+def check_skill(skill_dir: Path, errors: list[str]) -> None:
+    skill_md = skill_dir / "SKILL.md"
+    if not skill_md.is_file():
+        errors.append(f"{skill_dir}: missing SKILL.md")
+        return
+    fields = parse_frontmatter(skill_md, errors)
+    if fields.get("name") != skill_dir.name:
+        errors.append(
+            f"{skill_md}: frontmatter name {fields.get('name')!r} does not match {skill_dir.name!r}"
+        )
+    check_contract(skill_md, errors)
+    check_links(skill_md, errors)
+
+
+def main() -> int:
+    errors: list[str] = []
+    skill_dirs = sorted(path for path in SKILLS_ROOT.iterdir() if path.is_dir())
+    if not skill_dirs:
+        errors.append("skills/ contains no installable skills")
+
+    for skill_dir in skill_dirs:
+        check_skill(skill_dir, errors)
+
+    with tempfile.TemporaryDirectory(prefix="gtm-skill-loaders-") as temporary:
+        install_root = Path(temporary)
+        for loader_root in LOADER_ROOTS:
+            for skill_dir in skill_dirs:
+                installed = install_root / loader_root / skill_dir.name
+                shutil.copytree(skill_dir, installed)
+                check_skill(installed, errors)
+
+    if errors:
+        print("Skill compatibility check failed:")
+        for error in errors:
+            print(f"- {error}")
+        return 1
+
+    print(
+        f"Skill compatibility is valid: {len(skill_dirs)} skills across "
+        f"{len(LOADER_ROOTS)} offline loader shapes."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/gtm-icp/SKILL.md
+++ b/skills/gtm-icp/SKILL.md
@@ -13,6 +13,17 @@ Apply this Lifecycle SOP when the requested outcome creates, updates, repairs, o
 
 Own node-local, freeform Markdown ICPs at `icps/<icp-slug>/ICP.md` across creation, refinement, deletion, and repo-wide ICP integrity repair. Read legacy `icps/<icp-slug>.md` artifacts without requiring migration. Do not author persona or member files, manage the workspace lifecycle, or classify/research accounts against saved ICPs.
 
+**Contract**
+
+| Field | Public contract |
+| --- | --- |
+| Reads | Accepted ICP facts and uncertainty, the root-to-owner `ORG.md` chain, owner-local ICPs, and safe supplied sources |
+| Writes | Only the selected owner's canonical ICP path, or scoped ICP repairs during doctor |
+| Outputs | An accepted node-owned ICP and qualified label, a complete health report, or a scoped handoff |
+| Approval | The user accepts the complete bytes and exact path operation before any durable write or deletion |
+| Persists | Accepted ICP files in `main` Git history; no hidden coordination state |
+| Handoff | `gtm-workspace` for repository structure or connections, `gtm-persona` for buyers, and `gtm-workflow` for saved operational work |
+
 ## Inputs
 
 Use the user's accepted ICP facts and uncertainty, the hosting environment's connected-repo and durable-write declarations, the root-to-owner `ORG.md` chain, owner-local ICPs, and safe supplied sources.

--- a/skills/gtm-persona/SKILL.md
+++ b/skills/gtm-persona/SKILL.md
@@ -13,6 +13,17 @@ Apply this Lifecycle SOP when the requested outcome creates, updates, repairs, o
 
 Own node-local, freeform Markdown personas at `personas/<persona-slug>/PERSONA.md` across creation, refinement, deletion, and repo-wide persona integrity repair. Read legacy `personas/<persona-slug>.md` artifacts without requiring migration. Do not author ICP or member files, manage the workspace lifecycle, or classify/research leads against saved personas.
 
+**Contract**
+
+| Field | Public contract |
+| --- | --- |
+| Reads | Accepted persona facts and uncertainty, the root-to-owner `ORG.md` chain, owner-local personas, and safe supplied sources |
+| Writes | Only the selected owner's canonical persona path, or scoped persona repairs during doctor |
+| Outputs | An accepted node-owned persona and qualified label, a complete health report, or a scoped handoff |
+| Approval | The user accepts the complete bytes and exact path operation before any durable write or deletion |
+| Persists | Accepted persona files in `main` Git history; no hidden coordination state |
+| Handoff | `gtm-workspace` for repository structure or connections, `gtm-icp` for markets, and `gtm-workflow` for saved operational work |
+
 ## Inputs
 
 Use the user's accepted persona facts and uncertainty, the hosting environment's connected-repo and durable-write declarations, the root-to-owner `ORG.md` chain, owner-local personas, and safe supplied sources.

--- a/skills/gtm-workflow/SKILL.md
+++ b/skills/gtm-workflow/SKILL.md
@@ -13,6 +13,17 @@ Apply this Lifecycle SOP when a request creates, updates, inspects, deletes, run
 
 Own the root `workflows/` Nitro project, its managed workflows, typed tables, migrations, paid-call cache and ledger, local or Vercel runtime, native inspection tools, and deployment metadata. `gtm-workspace`, `gtm-icp`, and `gtm-persona` own their respective lifecycles.
 
+**Contract**
+
+| Field | Public contract |
+| --- | --- |
+| Reads | Accepted intent, workspace ownership and context files, current workflow code, supplied rows, environment-held credentials, caps, and deployment metadata |
+| Writes | The root workflow project, workflow-owned tables and adapters, committed migrations, and database rows created by accepted runs |
+| Outputs | An accepted workflow change, validation or deployment state, inspection result, or database-backed run outcome |
+| Approval | The user accepts tracked changes, production effect, real spend, external writes, checkpoint continuation, destruction, and credential entry |
+| Persists | Source and migrations in `main` Git history; results, cache, ledger, and run index in the database; retained execution traces in the runtime |
+| Handoff | `gtm-workspace` for repository structure or connections, `gtm-icp` for market definitions, and `gtm-persona` for buyer definitions |
+
 ## Inputs
 
 Use the accepted intent, resolved GTM workspace and owner, relevant ICP and persona files, current workflow project, supplied rows, provider documentation and credentials available through the environment, accepted caps, and deployment metadata.

--- a/skills/gtm-workspace/SKILL.md
+++ b/skills/gtm-workspace/SKILL.md
@@ -13,6 +13,17 @@ Apply this Lifecycle SOP when the requested outcome creates, imports, maintains,
 
 Own the plain-Markdown workspace at `~/.gtm/<org-slug>/` across creation, import, organization and member maintenance, legacy-shape migration, structural or Git repair, and deletion. Preserve node-owned ICP and persona artifacts without authoring or validating their contents.
 
+**Contract**
+
+| Field | Public contract |
+| --- | --- |
+| Reads | The user's accepted organization facts, repository connection rules, valid local workspaces, and safe supplied sources |
+| Writes | Workspace contract files, organization nodes, member files, repository configuration, and accepted structural repairs |
+| Outputs | The requested workspace state and path summary, a complete health report, or a fixed-connection refusal |
+| Approval | The user accepts every durable change and any whole-workspace deletion before it happens |
+| Persists | Accepted workspace files and configuration in `main` Git history; no hidden coordination state |
+| Handoff | `gtm-icp` for market definitions, `gtm-persona` for buyer definitions, and `gtm-workflow` for saved workflows |
+
 ## Inputs
 
 Use the user's request and accepted facts, the hosting environment's repo connection and durable-write declarations, valid local workspaces, and safe supplied sources.


### PR DESCRIPTION
## Summary

- Lead the README with typed owned results, paid-call caching and costs, the zero-spend preview and three-row checkpoint, and exact-commit production starts.
- Add security, contribution, version, compatibility, and changelog records.
- Give all four skills the same public Contract fields and enforce them with an offline loader check in CI.
- Publish the `gtm-lib-v10` tag on reviewed commit `55bd2ac`.

## Verification

- `python3 scripts/check_repo_layout.py`
- `python3 scripts/check_skill_compatibility.py`
- `node --test evals/gtm-workflow/scripts/test-templates.mjs`
- Workflow YAML parse
- Worked README query against an in-memory database
- Staged diff and reserved-path checks

Fixes #47