### PR TITLE
Validate runtime beta.46

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased, gtm-lib v11
+
+- Updated the pinned workflow runtime from beta.44 to beta.46 after the template suite passed on engine 22 and the forced webhook-resume probe passed on engine 24. The engine ceiling stays unchanged until the stable runtime declares support.
+
 ## gtm-lib v10, 2026-08-28
 
 - Cloud inspection now requires a read-only credential and rejects data-changing statements, including writes hidden behind a common table expression.

--- a/evals/gtm-workflow/scripts/test-templates.mjs
+++ b/evals/gtm-workflow/scripts/test-templates.mjs
@@ -13,6 +13,11 @@ test("v11 templates pass the deterministic workflow contract", async (context) =
   const directory = await mkdtemp(join(tmpdir(), "gtm-workflow-v11-"));
   let vendor;
   let server;
+  let releaseSlowRequest;
+  let markSlowRequestStarted;
+  const slowRequestStarted = new Promise((resolvePromise) => {
+    markSlowRequestStarted = resolvePromise;
+  });
   context.after(async () => {
     if (server) {
       try {
@@ -22,6 +27,7 @@ test("v11 templates pass the deterministic workflow contract", async (context) =
       server.stderr.destroy();
       server.unref();
     }
+    releaseSlowRequest?.();
     if (vendor) await new Promise((resolvePromise) => vendor.close(resolvePromise));
     await rm(directory, { recursive: true, force: true });
   });
@@ -73,8 +79,10 @@ test("v11 templates pass the deterministic workflow contract", async (context) =
         providerRecordId: `vendor-${vendorCalls}`,
       }),
     );
-    if (url.searchParams.get("domain") === "slow.test") setTimeout(send, 5_000);
-    else send();
+    if (url.searchParams.get("domain") === "slow.test") {
+      releaseSlowRequest = send;
+      markSlowRequestStarted();
+    } else send();
   });
   await new Promise((resolvePromise) => vendor.listen(0, "127.0.0.1", resolvePromise));
   const vendorPort = vendor.address().port;
@@ -511,7 +519,7 @@ test("v11 templates pass the deterministic workflow contract", async (context) =
   const slowInput = join(directory, "data/slow.json");
   await writeFile(slowInput, JSON.stringify({ rows: [{ key: "slow", domain: "slow.test" }] }));
   const slow = await gtm(directory, env, ["run", "slow-proof", "--input", slowInput]);
-  await waitForLedgerStatus(directory, env, slow.runKey, "pending");
+  await Promise.all([waitForLedgerStatus(directory, env, slow.runKey, "pending"), slowRequestStarted]);
   const bounded = await gtm(directory, env, ["runs", "get", slow.runKey, "--wait", "0.01"]);
   assert.equal(bounded.still_active, true);
   assert.equal(bounded.waiting_reason, "step running (slowLookup)");
@@ -520,6 +528,8 @@ test("v11 templates pass the deterministic workflow contract", async (context) =
   assert.equal(slowCancelling.finishedAt, null);
   const slowDuplicate = await gtmFailure(directory, env, ["run", "slow-proof", "--input", slowInput]);
   assert.equal(slowDuplicate.error.code, "run_in_progress");
+  releaseSlowRequest();
+  releaseSlowRequest = undefined;
   const slowCancelled = await gtm(directory, env, ["runs", "get", slow.runKey, "--wait"]);
   assert.equal(slowCancelled.status, "cancelled");
   assert.notEqual(slowCancelled.finishedAt, null);

--- a/skills/gtm-workflow/references/contract.md
+++ b/skills/gtm-workflow/references/contract.md
@@ -38,6 +38,8 @@ A v9 project lets cloud queries reuse the write credential and accepts data-chan
 
 A v10 project lacks provider discovery, bounded operator polling, row and step ledger attribution, selective reruns, command-generated diagrams, and receipt summaries. Offer the v11 recopy and its committed ledger migration through update.
 
+The v11 template pins runtime beta.46. It accepts the lazy hook-resume timing and ended-run behavior because approval state is checked in the database before every resume. The release also retains workflow VMs across attribute writes and safe boundaries with open hooks. The recovery, embedded data-directory, and engine-ceiling workarounds remain until stable 5.0.0 triggers the next review.
+
 ## Workflow and table contract
 
 Use a lowercase kebab-case filename and export its camelCase basename. Row workflows carry purpose, run location, kind, schedule when applicable, owner, ICP, providers with accepted unit cost, result table, and key meaning in the file header. Export `input`, `MAX_ROWS`, `MAX_SPEND_USD`, `COST_PER_ROW_USD`, the workflow function, and `scheduledInput` for scheduled work. The workflow takes `(arg: Input, meta: WorkflowMeta)` and assigns `arg = input.parse(arg)` immediately after `"use workflow"`; scheduled work sets `arg ??= scheduledInput` first.

--- a/skills/gtm-workflow/templates/package-lock.json
+++ b/skills/gtm-workflow/templates/package-lock.json
@@ -13,7 +13,7 @@
         "drizzle-orm": "0.45.2",
         "drizzle-zod": "0.8.3",
         "nitro": "3.0.260610-beta",
-        "workflow": "5.0.0-beta.44",
+        "workflow": "5.0.0-beta.46",
         "zod": "4.4.3"
       },
       "devDependencies": {
@@ -1157,9 +1157,9 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
-      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.6.0.tgz",
+      "integrity": "sha512-T7jf+5zgsZHwNJ4lvQ7/aezbyk0nNX+zJVWpmHA7VYsEx7a7qr5Rg5IbtJFqkgze5Y2sruq1RUY8Q837Od7iFw==",
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
@@ -1491,9 +1491,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1510,9 +1507,6 @@
       "integrity": "sha512-+2Rzdb3nTIYZ0YJF43qf2twhqOCkiSrHx2Pg6DJaCPYhhaxbLcdlV8hCRMHghQ+EtZQWGNcS2xF4KxBhSGeutg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1531,9 +1525,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1550,9 +1541,6 @@
       "integrity": "sha512-HU0nw9uD4FO/oGCCk409tCi5IzIZpH2agE6nN4fqpwVlCn5BOq0MS1dXGjXaG17JaAvrlpV5ZeyZwSon10XOXw==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -1571,9 +1559,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1591,9 +1576,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1610,9 +1592,6 @@
       "integrity": "sha512-xScCGnyj/oppsNPMnevsBe3pvNaoK7FGvMjT35riz9YdhB2WtTG47ZlbxtOLpjeO9SqqQ2J2igCmz6IJOD5JYw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1699,13 +1678,14 @@
       "license": "MIT"
     },
     "node_modules/@nestjs/common": {
-      "version": "11.2.3",
-      "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.2.3.tgz",
-      "integrity": "sha512-obdauJXHfthhepbV+LpGe88OeBlR/Kw9lwjLo0Utzc//agoLXYb9DUGhPQWtm81IpBWMv+19eiwcve9MsBZwXA==",
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-12.0.1.tgz",
+      "integrity": "sha512-v0zTaRCTV2K2xSnb3GnJoQKtaR6VxouJtm+P2gpr5w61dlXeWpXl1WVknCSzUqx2QwTV10tBkHETxvQvkf2Exg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "file-type": "21.3.4",
+        "@standard-schema/spec": "1.1.0",
+        "file-type": "22.0.2",
         "iterare": "1.2.1",
         "load-esm": "1.0.3",
         "tslib": "2.8.1",
@@ -1731,9 +1711,9 @@
       }
     },
     "node_modules/@nestjs/core": {
-      "version": "11.2.3",
-      "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-11.2.3.tgz",
-      "integrity": "sha512-vkA9/Ja0Z3hvqXErSa+HaxrfF+cNXthNFi8VPNEKVli4rMd009yExAl0gLmko/Kf8peDXr72u1RN+j9Da2ukHg==",
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-12.0.1.tgz",
+      "integrity": "sha512-rU6tAi8vDdyzHgN0iW0J4UJvziroOqzHqzlqL7phOSPizaXVEePfv+OUOsdJEOh0Qd14mslc3udOheLrAEcZow==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -1751,10 +1731,10 @@
         "url": "https://opencollective.com/nest"
       },
       "peerDependencies": {
-        "@nestjs/common": "^11.0.0",
-        "@nestjs/microservices": "^11.0.0",
-        "@nestjs/platform-express": "^11.0.0",
-        "@nestjs/websockets": "^11.0.0",
+        "@nestjs/common": "^12.0.0",
+        "@nestjs/microservices": "^12.0.0",
+        "@nestjs/platform-express": "^12.0.0",
+        "@nestjs/websockets": "^12.0.0",
         "reflect-metadata": "^0.1.12 || ^0.2.0",
         "rxjs": "^7.1.0"
       },
@@ -1990,9 +1970,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2008,9 +1985,6 @@
       "integrity": "sha512-xMvZgnbZg4YVnR/AX2b3oOPDTFYJvUVaJg5FedA/LuvexAtXibZQej4cnTkw3rjsJ/ggUROB64TdtETiim+FYA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2028,9 +2002,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2046,9 +2017,6 @@
       "integrity": "sha512-vLNTR45F2Uwc8AufkNXPmB4VliaXs+FvcheEogIzOXzO4l+LzieXF5A/TWxLy5HtqpsRCHUfd0lPVrrdgXdLHQ==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -2066,9 +2034,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2084,9 +2049,6 @@
       "integrity": "sha512-mY8AP0/ichsbhAxGnLa3d3+MwV0EfgrPND2bplI3Ym8T6R2pJ0N87bvrKVwNXmdy3jnr6eQBecdqx/HMknBmpA==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2394,9 +2356,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -2412,9 +2371,6 @@
       "integrity": "sha512-j4SJniZ/qaZ5g8op+p1G9K1z22s/EYGg1UXIb3+Cg4nsxEpF5uSIGEE4mHUfA70L0BR9wKT2QF/zv3vkhfpX4g==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
@@ -2432,9 +2388,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -2450,9 +2403,6 @@
       "integrity": "sha512-oe8FctPu1gnUsdtGJRO2rvOUIkkIIaHqsO9xxN0bTR7dFTlPTGi2Fhk1tnvXeyAvCPxLIcwD8phzKg6wLv9yug==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
@@ -2595,6 +2545,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2611,6 +2562,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2627,6 +2579,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2643,6 +2596,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2659,6 +2613,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2675,6 +2630,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2691,6 +2647,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2707,6 +2664,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2723,6 +2681,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2739,6 +2698,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2755,6 +2715,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2771,6 +2732,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2787,6 +2749,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2803,6 +2766,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2819,6 +2783,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2835,6 +2800,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2851,6 +2817,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2867,6 +2834,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2883,6 +2851,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2899,6 +2868,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3130,29 +3100,99 @@
         "node": ">= 20"
       }
     },
+    "node_modules/@vercel/queue": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@vercel/queue/-/queue-0.3.1.tgz",
+      "integrity": "sha512-6pjdXyNfdCQnj1nyeB1rPtll/XUhmciyeZJD0rpIUUwmcIfR+utDl6+iFvlHvsBdqAVT8UC6ydObT0v+xldfUQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@vercel/oidc": "^3.0.5",
+        "minimatch": "^10.2.4",
+        "mixpart": "0.0.6",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@vercel/queue/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@vercel/queue/node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@vercel/queue/node_modules/minimatch": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "license": "BlueOak-1.0.0",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "brace-expansion": "^5.0.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@vercel/queue/node_modules/mixpart": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/mixpart/-/mixpart-0.0.6.tgz",
+      "integrity": "sha512-CRdXtgfQH2jARmtNmPR0Q7jL20fiESbaYk1b0KvLD0jCdUuemepREtsbd8nbiY6BHV9OGGddAZITNXklupUPUQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@workflow/astro": {
-      "version": "5.0.0-beta.44",
-      "resolved": "https://registry.npmjs.org/@workflow/astro/-/astro-5.0.0-beta.44.tgz",
-      "integrity": "sha512-qzrby4jdtFrJePeacq4M5YGa0KbquaaNm4O1SxHmOfmcgjG21Bm14CUgcAtpuNeDeQadMblnCAQ9Y44zxbonyw==",
+      "version": "5.0.0-beta.46",
+      "resolved": "https://registry.npmjs.org/@workflow/astro/-/astro-5.0.0-beta.46.tgz",
+      "integrity": "sha512-gDjsYb6tFmNlHFHxfKHI+3sOutWZVn8V/P602akXUxAi3BwPKvGrRTvKaaQh6nb0Z+yJUFr0Au1yT+9ixuJ92g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/core": "1.15.3",
-        "@workflow/builders": "5.0.0-beta.44",
-        "@workflow/rollup": "5.0.0-beta.44",
+        "@workflow/builders": "5.0.0-beta.46",
+        "@workflow/rollup": "5.0.0-beta.46",
         "@workflow/swc-plugin": "5.0.0-beta.5",
-        "@workflow/vite": "5.0.0-beta.44",
+        "@workflow/vite": "5.0.0-beta.46",
         "exsolve": "^1.0.8",
         "pathe": "^2.0.3"
       }
     },
     "node_modules/@workflow/builders": {
-      "version": "5.0.0-beta.44",
-      "resolved": "https://registry.npmjs.org/@workflow/builders/-/builders-5.0.0-beta.44.tgz",
-      "integrity": "sha512-GqbujuOGppDDVt27qOl15fPpgoTbNMc2+/2VEmuhnQmC9vVcmwFrLGf1aAnGsZl1xYpn1+IT97317mdW095VFw==",
+      "version": "5.0.0-beta.46",
+      "resolved": "https://registry.npmjs.org/@workflow/builders/-/builders-5.0.0-beta.46.tgz",
+      "integrity": "sha512-JfR4insHWteCbQDfkpiGKDrquup9Tj2KgqRdWZkTeNez8CbHZzZqGeh6eUXZq5fcIir+iypK2OWbRmp22PYn/g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/core": "1.15.3",
-        "@workflow/core": "5.0.0-beta.44",
+        "@workflow/core": "5.0.0-beta.46",
         "@workflow/errors": "5.0.0-beta.18",
         "@workflow/swc-plugin": "5.0.0-beta.5",
         "@workflow/utils": "5.0.0-beta.9",
@@ -3166,24 +3206,24 @@
       }
     },
     "node_modules/@workflow/cli": {
-      "version": "5.0.0-beta.44",
-      "resolved": "https://registry.npmjs.org/@workflow/cli/-/cli-5.0.0-beta.44.tgz",
-      "integrity": "sha512-ZEj1JeymZEWdGAgsfpVYtkb3mqztYp4hFgrt1J7WdDeo4n2qXD4VEksDJ8mnb9LXI+1rAlECEBlXZvdMKpLWNg==",
+      "version": "5.0.0-beta.46",
+      "resolved": "https://registry.npmjs.org/@workflow/cli/-/cli-5.0.0-beta.46.tgz",
+      "integrity": "sha512-1QtMLG+EemBOwcuuMhW9vRqjhUJ2hE+LJW5jEt/I2xj4FS/sA4x/3PjdBwl0saFiHKzi+NQ9iQWAZdrfto9VuA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@oclif/core": "4.11.4",
         "@oclif/plugin-help": "6.2.37",
         "@swc/core": "1.15.3",
         "@vercel/cli-auth": "0.0.1",
-        "@workflow/builders": "5.0.0-beta.44",
-        "@workflow/core": "5.0.0-beta.44",
+        "@workflow/builders": "5.0.0-beta.46",
+        "@workflow/core": "5.0.0-beta.46",
         "@workflow/errors": "5.0.0-beta.18",
         "@workflow/swc-plugin": "5.0.0-beta.5",
         "@workflow/utils": "5.0.0-beta.9",
-        "@workflow/web": "5.0.0-beta.44",
-        "@workflow/world": "5.0.0-beta.29",
-        "@workflow/world-local": "5.0.0-beta.38",
-        "@workflow/world-vercel": "5.0.0-beta.40",
+        "@workflow/web": "5.0.0-beta.46",
+        "@workflow/world": "5.0.0-beta.31",
+        "@workflow/world-local": "5.0.0-beta.40",
+        "@workflow/world-vercel": "5.0.0-beta.42",
         "boxen": "8.0.1",
         "builtin-modules": "5.0.0",
         "chalk": "5.6.2",
@@ -3245,9 +3285,9 @@
       }
     },
     "node_modules/@workflow/core": {
-      "version": "5.0.0-beta.44",
-      "resolved": "https://registry.npmjs.org/@workflow/core/-/core-5.0.0-beta.44.tgz",
-      "integrity": "sha512-LaQfLMCYTHnV8cZtMhXROIOld61xi0c0LlxH24d7ToHoh6hrzKN8lAh04ZccFRQ+/Qo0f+7ewItUmSSxDiZncQ==",
+      "version": "5.0.0-beta.46",
+      "resolved": "https://registry.npmjs.org/@workflow/core/-/core-5.0.0-beta.46.tgz",
+      "integrity": "sha512-MIp2OxOaqkY+z/4/bxhEqaqZXZmk690VPyyDvVBmAWka1e2rG0PMd+REEPqArmBVc80v52e8cZbiYBOqJ3IgHQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/credential-provider-web-identity": "3.972.49",
@@ -3258,9 +3298,9 @@
         "@workflow/errors": "5.0.0-beta.18",
         "@workflow/serde": "5.0.0-beta.2",
         "@workflow/utils": "5.0.0-beta.9",
-        "@workflow/world": "5.0.0-beta.29",
-        "@workflow/world-local": "5.0.0-beta.38",
-        "@workflow/world-vercel": "5.0.0-beta.40",
+        "@workflow/world": "5.0.0-beta.31",
+        "@workflow/world-local": "5.0.0-beta.40",
+        "@workflow/world-vercel": "5.0.0-beta.42",
         "debug": "4.4.3",
         "devalue": "5.9.0",
         "ms": "2.1.3",
@@ -3324,13 +3364,13 @@
       }
     },
     "node_modules/@workflow/nest": {
-      "version": "5.0.0-beta.44",
-      "resolved": "https://registry.npmjs.org/@workflow/nest/-/nest-5.0.0-beta.44.tgz",
-      "integrity": "sha512-oGomnmpAG9Q0ubuZpQpek8KEoQi6n/f+Ippm+vx6MjJSGlgdmBRczvrZPcJIlpUDLfG7wblBgv4TGfYoQVWV9g==",
+      "version": "5.0.0-beta.46",
+      "resolved": "https://registry.npmjs.org/@workflow/nest/-/nest-5.0.0-beta.46.tgz",
+      "integrity": "sha512-yD7VUncDmGuOGXAFd1ybwAKT94+lCo3bo6LS6afIH8bMA571iXvNxhHQxEgvi6/Z3IGwZB7vS7P5PGk2owibxQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/core": "1.15.3",
-        "@workflow/builders": "5.0.0-beta.44",
+        "@workflow/builders": "5.0.0-beta.46",
         "@workflow/swc-plugin": "5.0.0-beta.5",
         "@workflow/utils": "5.0.0-beta.9",
         "esbuild": "^0.28.1",
@@ -3361,14 +3401,14 @@
       }
     },
     "node_modules/@workflow/next": {
-      "version": "5.0.0-beta.44",
-      "resolved": "https://registry.npmjs.org/@workflow/next/-/next-5.0.0-beta.44.tgz",
-      "integrity": "sha512-fee7xBgBmNNtaZcyiXgLYG3qTujFUz4UOCafVutvkTcIuDmel4p/F8alRyTFxPTseHH2eGgdDfXK5tsqGRiIcA==",
+      "version": "5.0.0-beta.46",
+      "resolved": "https://registry.npmjs.org/@workflow/next/-/next-5.0.0-beta.46.tgz",
+      "integrity": "sha512-/jQxg/zwDIe7A3KaHjSN8Ca/zUMezq9j5eym4Vif1H+AGxNuAk8i3lc4C7zuhiBJi3GYxzj07jfwL+DPQe7VOg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/core": "1.15.3",
-        "@workflow/builders": "5.0.0-beta.44",
-        "@workflow/core": "5.0.0-beta.44",
+        "@workflow/builders": "5.0.0-beta.46",
+        "@workflow/core": "5.0.0-beta.46",
         "@workflow/swc-plugin": "5.0.0-beta.5",
         "chokidar": "4.0.3",
         "ignore": "7.0.5",
@@ -3424,18 +3464,18 @@
       }
     },
     "node_modules/@workflow/nitro": {
-      "version": "5.0.0-beta.44",
-      "resolved": "https://registry.npmjs.org/@workflow/nitro/-/nitro-5.0.0-beta.44.tgz",
-      "integrity": "sha512-FdmPF3unPV1t6DNXK/DOchjaCd8RyjQinQUKdITCb6GZvQoHdQHKglPNR6B6jlDZV1O6yTTl/jtNTCDpiCc4Jw==",
+      "version": "5.0.0-beta.46",
+      "resolved": "https://registry.npmjs.org/@workflow/nitro/-/nitro-5.0.0-beta.46.tgz",
+      "integrity": "sha512-s/JlH4KvUMGWt0Km4vJ2jKp/mI1+iVuB9ZsGLYPn1Y47r0CSX77pyo9x0fBLyRAYcREDoiqVBSs0tn+WQhXoXw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/core": "1.15.3",
-        "@workflow/builders": "5.0.0-beta.44",
-        "@workflow/core": "5.0.0-beta.44",
-        "@workflow/rollup": "5.0.0-beta.44",
+        "@workflow/builders": "5.0.0-beta.46",
+        "@workflow/core": "5.0.0-beta.46",
+        "@workflow/rollup": "5.0.0-beta.46",
         "@workflow/swc-plugin": "5.0.0-beta.5",
-        "@workflow/vite": "5.0.0-beta.44",
-        "@workflow/web": "5.0.0-beta.44",
+        "@workflow/vite": "5.0.0-beta.46",
+        "@workflow/web": "5.0.0-beta.46",
         "exsolve": "1.0.8",
         "pathe": "2.0.3"
       }
@@ -3447,23 +3487,23 @@
       "license": "MIT"
     },
     "node_modules/@workflow/nuxt": {
-      "version": "5.0.0-beta.44",
-      "resolved": "https://registry.npmjs.org/@workflow/nuxt/-/nuxt-5.0.0-beta.44.tgz",
-      "integrity": "sha512-YI5UHkohFW7v8d6v6q8BfG8U8eLBCcKvJCswCro0WDqU4Fv9uVvtlPKjdu1XdOIOdDhCUCskbzcLEgdddhJxKg==",
+      "version": "5.0.0-beta.46",
+      "resolved": "https://registry.npmjs.org/@workflow/nuxt/-/nuxt-5.0.0-beta.46.tgz",
+      "integrity": "sha512-3IZxD7oqnM19JTc2XdaFYZwXkvqjHA/mQXulYTRQLs7xIK39k+c+Ms/2D1Q3SW1r8hz/kc6wOA5SasUcgPar4Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "@nuxt/kit": "4.4.8",
-        "@workflow/nitro": "5.0.0-beta.44"
+        "@workflow/nitro": "5.0.0-beta.46"
       }
     },
     "node_modules/@workflow/rollup": {
-      "version": "5.0.0-beta.44",
-      "resolved": "https://registry.npmjs.org/@workflow/rollup/-/rollup-5.0.0-beta.44.tgz",
-      "integrity": "sha512-D9VEg+8Mk0sEqUAGjiuW7OdUrorBnoBF1sHTgLv9Emf/7Qy0ecYI/ziUyFbA4AG2KF2A/X8csjgnL7gQWN9oew==",
+      "version": "5.0.0-beta.46",
+      "resolved": "https://registry.npmjs.org/@workflow/rollup/-/rollup-5.0.0-beta.46.tgz",
+      "integrity": "sha512-6Fe/5B3OrROp9qyPtz1gN+fErqSl2SOELVdquALFL/KouFmb8EW3kz2HKTY9j66HOD7CXFSmhQNa41L1ln+5Uw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/core": "1.15.3",
-        "@workflow/builders": "5.0.0-beta.44",
+        "@workflow/builders": "5.0.0-beta.46",
         "@workflow/swc-plugin": "5.0.0-beta.5",
         "exsolve": "1.0.7"
       }
@@ -3481,17 +3521,17 @@
       "license": "Apache-2.0"
     },
     "node_modules/@workflow/sveltekit": {
-      "version": "5.0.0-beta.44",
-      "resolved": "https://registry.npmjs.org/@workflow/sveltekit/-/sveltekit-5.0.0-beta.44.tgz",
-      "integrity": "sha512-Z6syn0U3GRZQmIU0hYEKMxnIfoIrSeifVNDiU5ugMRXMgqM0LIX5p9VRci84PQXovWJQKNH2g1BXWk8AbZAyhQ==",
+      "version": "5.0.0-beta.46",
+      "resolved": "https://registry.npmjs.org/@workflow/sveltekit/-/sveltekit-5.0.0-beta.46.tgz",
+      "integrity": "sha512-kNZob4mAtjJhEgF+VVAY0bjjh79Irl7lgjkRjmoifYK0ZRjf3mWYkpd1eGF0fxVzEbLQLslEwoqE5u2I0zBNDg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@sveltejs/load-config": "^0.2.3",
         "@swc/core": "1.15.3",
-        "@workflow/builders": "5.0.0-beta.44",
-        "@workflow/rollup": "5.0.0-beta.44",
+        "@workflow/builders": "5.0.0-beta.46",
+        "@workflow/rollup": "5.0.0-beta.46",
         "@workflow/swc-plugin": "5.0.0-beta.5",
-        "@workflow/vite": "5.0.0-beta.44",
+        "@workflow/vite": "5.0.0-beta.46",
         "exsolve": "^1.0.8",
         "fs-extra": "^11.3.2",
         "pathe": "^2.0.3"
@@ -3530,29 +3570,29 @@
       }
     },
     "node_modules/@workflow/vite": {
-      "version": "5.0.0-beta.44",
-      "resolved": "https://registry.npmjs.org/@workflow/vite/-/vite-5.0.0-beta.44.tgz",
-      "integrity": "sha512-Kr/F9Xzmg6lr4xtsGDPXemh3bpGmFlyOBRVeUapdc4YIKp7/1arMyBdI93b0CYBFXa7IcO7LjSn2NY8oW55Yew==",
+      "version": "5.0.0-beta.46",
+      "resolved": "https://registry.npmjs.org/@workflow/vite/-/vite-5.0.0-beta.46.tgz",
+      "integrity": "sha512-m++6Xd0qECTYUE/hkV8oN+WkJ8KQTlO8naajcCs2DAQyZF5eMUuT1agj3NSKNjoAZUXkwpqSm3LT2Kq9x56ibQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@workflow/builders": "5.0.0-beta.44"
+        "@workflow/builders": "5.0.0-beta.46"
       }
     },
     "node_modules/@workflow/web": {
-      "version": "5.0.0-beta.44",
-      "resolved": "https://registry.npmjs.org/@workflow/web/-/web-5.0.0-beta.44.tgz",
-      "integrity": "sha512-T/CgeX0hSia7F3l1MGs/5SccbSROfRfLzzopcO6z5fjj4KrwiHnVpKAcEtbva37gStQFSw4bhjuE5bRNGd0WxA==",
+      "version": "5.0.0-beta.46",
+      "resolved": "https://registry.npmjs.org/@workflow/web/-/web-5.0.0-beta.46.tgz",
+      "integrity": "sha512-AZcHC6MQ8eYKFTO/Zu8jvgZ7ycrf7VC/G/uHIBrSGHaGcIBEpYO87MFl0vbImMnG7jpmAminuG58Pi4eZNjggA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@workflow/world-local": "5.0.0-beta.38",
+        "@workflow/world-local": "5.0.0-beta.40",
         "express": "^5.2.1",
         "swr": "^2.3.6"
       }
     },
     "node_modules/@workflow/world": {
-      "version": "5.0.0-beta.29",
-      "resolved": "https://registry.npmjs.org/@workflow/world/-/world-5.0.0-beta.29.tgz",
-      "integrity": "sha512-3z5GHEJgvb2AFfznQ4JfT1rm5U9jNupuG4YtrUUrtJ+807JkcjhP85fMN7Jo30975CcPPgnZmlnYI4sM0Y1d/w==",
+      "version": "5.0.0-beta.31",
+      "resolved": "https://registry.npmjs.org/@workflow/world/-/world-5.0.0-beta.31.tgz",
+      "integrity": "sha512-+aYkb841BpJmZ9I4Ivx7924xzb+yau+u5JcpXIs4eTOwFZaAuJpEEdAdtM/+7r6ku0wS/MLUQaWm2O16ZyU46w==",
       "license": "Apache-2.0",
       "dependencies": {
         "ulid": "~3.0.1",
@@ -3560,15 +3600,15 @@
       }
     },
     "node_modules/@workflow/world-local": {
-      "version": "5.0.0-beta.38",
-      "resolved": "https://registry.npmjs.org/@workflow/world-local/-/world-local-5.0.0-beta.38.tgz",
-      "integrity": "sha512-XOTfsmiaV3F9qzAWDyoHmAn8RYnVLouE4E6254kxc5VfzrOXsW5jcfIXHhRC6dwGYNC2aZVjiX4SMV2io8Ardw==",
+      "version": "5.0.0-beta.40",
+      "resolved": "https://registry.npmjs.org/@workflow/world-local/-/world-local-5.0.0-beta.40.tgz",
+      "integrity": "sha512-6nquVqHyjbIHJI6+GzjRKa5DsNIILNhpLGoou7ZaQr07iLaX0dQ/c4cfjCqiVDi5cGskMg6Rwm8ILeGLP1AM7g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@vercel/queue": "0.5.0",
         "@workflow/errors": "5.0.0-beta.18",
         "@workflow/utils": "5.0.0-beta.9",
-        "@workflow/world": "5.0.0-beta.29",
+        "@workflow/world": "5.0.0-beta.31",
         "async-sema": "3.1.1",
         "proper-lockfile": "4.1.2",
         "ulid": "~3.0.1",
@@ -3662,9 +3702,9 @@
       }
     },
     "node_modules/@workflow/world-vercel": {
-      "version": "5.0.0-beta.40",
-      "resolved": "https://registry.npmjs.org/@workflow/world-vercel/-/world-vercel-5.0.0-beta.40.tgz",
-      "integrity": "sha512-QDh5Zi/OeIBK5O3zRHG0yPhDAplcXoCgODivq6WGgvKWwvSNVUiBswtu+R4uCB7HnZCzJgSC/knc5yE09vnZXA==",
+      "version": "5.0.0-beta.42",
+      "resolved": "https://registry.npmjs.org/@workflow/world-vercel/-/world-vercel-5.0.0-beta.42.tgz",
+      "integrity": "sha512-irTlWijQ9QrC43Gqc7p9HBeYl1NZB+3jICZ4Ki1AoOq/0YeJu4FtTEmWoI9nRtIwZG2ui50wW2+KESbiB0RVeg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@vercel/functions": "^3.8.0",
@@ -3672,7 +3712,7 @@
         "@vercel/queue": "0.5.0",
         "@workflow/errors": "5.0.0-beta.18",
         "@workflow/utils": "5.0.0-beta.9",
-        "@workflow/world": "5.0.0-beta.29",
+        "@workflow/world": "5.0.0-beta.31",
         "cbor-x": "1.6.0",
         "ulid": "~3.0.1",
         "undici": "7.29.0",
@@ -3787,6 +3827,25 @@
         "node": ">=20"
       }
     },
+    "node_modules/@xhmikosr/archive-type/node_modules/file-type": {
+      "version": "21.3.4",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.4.tgz",
+      "integrity": "sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@tokenizer/inflate": "^0.4.1",
+        "strtok3": "^10.3.4",
+        "token-types": "^6.1.1",
+        "uint8array-extras": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/file-type?sponsor=1"
+      }
+    },
     "node_modules/@xhmikosr/bin-check": {
       "version": "8.2.2",
       "resolved": "https://registry.npmjs.org/@xhmikosr/bin-check/-/bin-check-8.2.2.tgz",
@@ -3850,6 +3909,25 @@
         "node": ">=20"
       }
     },
+    "node_modules/@xhmikosr/decompress-tar/node_modules/file-type": {
+      "version": "21.3.4",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.4.tgz",
+      "integrity": "sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@tokenizer/inflate": "^0.4.1",
+        "strtok3": "^10.3.4",
+        "token-types": "^6.1.1",
+        "uint8array-extras": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/file-type?sponsor=1"
+      }
+    },
     "node_modules/@xhmikosr/decompress-tarbz2": {
       "version": "9.0.2",
       "resolved": "https://registry.npmjs.org/@xhmikosr/decompress-tarbz2/-/decompress-tarbz2-9.0.2.tgz",
@@ -3867,6 +3945,25 @@
         "node": ">=20"
       }
     },
+    "node_modules/@xhmikosr/decompress-tarbz2/node_modules/file-type": {
+      "version": "21.3.4",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.4.tgz",
+      "integrity": "sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@tokenizer/inflate": "^0.4.1",
+        "strtok3": "^10.3.4",
+        "token-types": "^6.1.1",
+        "uint8array-extras": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/file-type?sponsor=1"
+      }
+    },
     "node_modules/@xhmikosr/decompress-targz": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/@xhmikosr/decompress-targz/-/decompress-targz-9.0.1.tgz",
@@ -3882,6 +3979,25 @@
         "node": ">=20"
       }
     },
+    "node_modules/@xhmikosr/decompress-targz/node_modules/file-type": {
+      "version": "21.3.4",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.4.tgz",
+      "integrity": "sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@tokenizer/inflate": "^0.4.1",
+        "strtok3": "^10.3.4",
+        "token-types": "^6.1.1",
+        "uint8array-extras": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/file-type?sponsor=1"
+      }
+    },
     "node_modules/@xhmikosr/decompress-unzip": {
       "version": "8.2.1",
       "resolved": "https://registry.npmjs.org/@xhmikosr/decompress-unzip/-/decompress-unzip-8.2.1.tgz",
@@ -3895,6 +4011,25 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/@xhmikosr/decompress-unzip/node_modules/file-type": {
+      "version": "21.3.4",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.4.tgz",
+      "integrity": "sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@tokenizer/inflate": "^0.4.1",
+        "strtok3": "^10.3.4",
+        "token-types": "^6.1.1",
+        "uint8array-extras": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/file-type?sponsor=1"
       }
     },
     "node_modules/@xhmikosr/downloader": {
@@ -3914,6 +4049,25 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/@xhmikosr/downloader/node_modules/file-type": {
+      "version": "21.3.4",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.4.tgz",
+      "integrity": "sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@tokenizer/inflate": "^0.4.1",
+        "strtok3": "^10.3.4",
+        "token-types": "^6.1.1",
+        "uint8array-extras": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/file-type?sponsor=1"
       }
     },
     "node_modules/@xhmikosr/os-filter-obj": {
@@ -4071,9 +4225,9 @@
       "license": "MIT"
     },
     "node_modules/bare-events": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.9.1.tgz",
-      "integrity": "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==",
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.9.2.tgz",
+      "integrity": "sha512-AIPKioV7/Y/8KfZ3AAhjPJxLLbY49S64Ym5DakZlUg75qQiTgUq9hEJoEwa4eUezPUlXRy/i5NpsKvo9jgKmoA==",
       "license": "Apache-2.0",
       "peer": true,
       "peerDependencies": {
@@ -6101,19 +6255,19 @@
       }
     },
     "node_modules/file-type": {
-      "version": "21.3.4",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.4.tgz",
-      "integrity": "sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==",
+      "version": "22.0.2",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-22.0.2.tgz",
+      "integrity": "sha512-0H8TsCUGBLx+V5adH3EY52hTAcyLKbV1D4gq5cIOJ6DnQAHeV9Z2Hhuc5CoBX4YmvB2oL+JIC84z0qO7JsCoNw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "@tokenizer/inflate": "^0.4.1",
-        "strtok3": "^10.3.4",
-        "token-types": "^6.1.1",
-        "uint8array-extras": "^1.4.0"
+        "strtok3": "^10.3.5",
+        "token-types": "^6.1.2",
+        "uint8array-extras": "^1.5.0"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
       },
       "funding": {
         "url": "https://github.com/sindresorhus/file-type?sponsor=1"
@@ -7724,9 +7878,9 @@
       }
     },
     "node_modules/piscina": {
-      "version": "4.9.3",
-      "resolved": "https://registry.npmjs.org/piscina/-/piscina-4.9.3.tgz",
-      "integrity": "sha512-3e3ka9QCE8RJ5I9uszdAADZnkcYi21cqmF3gxox3u884N72qpFHCsIVhHt8cEQ9t3Auq/NqoiCEuhxlxxQuDWA==",
+      "version": "4.9.4",
+      "resolved": "https://registry.npmjs.org/piscina/-/piscina-4.9.4.tgz",
+      "integrity": "sha512-RyBDr2VheQ8ZfH3N8SzQZHztqVyOtadTwLnUYof6gdj5161/eu2wNhCbGl5GHnNKDpnkicJYpKtL2J+y/gk6XA==",
       "license": "MIT",
       "peer": true,
       "optionalDependencies": {
@@ -8384,9 +8538,9 @@
       }
     },
     "node_modules/streamx": {
-      "version": "2.28.0",
-      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.28.0.tgz",
-      "integrity": "sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==",
+      "version": "2.28.1",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.28.1.tgz",
+      "integrity": "sha512-zEzXb0s5Cds7tqMH6rhZ05lcJydCWiQPEwiNngVqzsxCc962vLY4Uw+mW7od8kDH258k2Uz/JrOkdIAAhSh9VA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -9166,21 +9320,21 @@
       "license": "MIT"
     },
     "node_modules/workflow": {
-      "version": "5.0.0-beta.44",
-      "resolved": "https://registry.npmjs.org/workflow/-/workflow-5.0.0-beta.44.tgz",
-      "integrity": "sha512-ANthKwwqYdce6YoCB+MpKGXRHEpFeY8x3WuHmE+heDOmiumYaGbdoA7SQLn4WPGprS+/+0XVrw1+xz/oLEcd7Q==",
+      "version": "5.0.0-beta.46",
+      "resolved": "https://registry.npmjs.org/workflow/-/workflow-5.0.0-beta.46.tgz",
+      "integrity": "sha512-RwRn7RfQMIwb4PRtaLDfBu2bzp/1kUeVaLlEXNzRQ5xA44Nj5c6dsPtU2SwyitdK+nW9g/HCFcdBO6mJ/aJQGg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@workflow/astro": "5.0.0-beta.44",
-        "@workflow/cli": "5.0.0-beta.44",
-        "@workflow/core": "5.0.0-beta.44",
+        "@workflow/astro": "5.0.0-beta.46",
+        "@workflow/cli": "5.0.0-beta.46",
+        "@workflow/core": "5.0.0-beta.46",
         "@workflow/errors": "5.0.0-beta.18",
-        "@workflow/nest": "5.0.0-beta.44",
-        "@workflow/next": "5.0.0-beta.44",
-        "@workflow/nitro": "5.0.0-beta.44",
-        "@workflow/nuxt": "5.0.0-beta.44",
-        "@workflow/rollup": "5.0.0-beta.44",
-        "@workflow/sveltekit": "5.0.0-beta.44",
+        "@workflow/nest": "5.0.0-beta.46",
+        "@workflow/next": "5.0.0-beta.46",
+        "@workflow/nitro": "5.0.0-beta.46",
+        "@workflow/nuxt": "5.0.0-beta.46",
+        "@workflow/rollup": "5.0.0-beta.46",
+        "@workflow/sveltekit": "5.0.0-beta.46",
         "@workflow/typescript-plugin": "5.0.0-beta.5",
         "@workflow/utils": "5.0.0-beta.9",
         "ms": "2.1.3"

--- a/skills/gtm-workflow/templates/package.json
+++ b/skills/gtm-workflow/templates/package.json
@@ -23,7 +23,7 @@
     "drizzle-orm": "0.45.2",
     "drizzle-zod": "0.8.3",
     "nitro": "3.0.260610-beta",
-    "workflow": "5.0.0-beta.44",
+    "workflow": "5.0.0-beta.46",
     "zod": "4.4.3"
   },
   "devDependencies": {
@@ -63,7 +63,7 @@
       "server/api/runs/[runId]/trigger.post.ts": "a6e42ed5baa4996bb1c55d86877cfe15a5a399dfee591385f5c65d38f0b4f7fa"
     },
     "validatedAgainst": {
-      "workflow": "5.0.0-beta.44",
+      "workflow": "5.0.0-beta.46",
       "nitro": "3.0.260610-beta",
       "drizzleKit": "0.31.10",
       "node": "22"


### PR DESCRIPTION
## Summary

- Bump the exact runtime pin from beta.44 to beta.46 and regenerate the lockfile with the existing framework pin.
- Record the validated runtime version and the behavior changes that affect approval resumes.
- Add the unreleased v11 changelog entry without changing managed source files or the library version.
- Replace the timing-based cancellation fixture with an explicit gate so slow runners cannot finish the paid step before the duplicate-run assertion.

The candidate was published on 2026-08-26 and validated on 2026-08-28 at explicit maintainer direction. This is shorter than the preferred seven-day soak.

## Release notes read

- beta.44 baseline notes.
- beta.46 candidate notes. Lazy hook resumes now let the queue consumer record receipt, resumes against ended runs can resolve, and internal abort resumes keep the eager receipt write. Workflow VMs stay live across attribute writes and safe boundaries with open hooks. Serialization diagnostics are bounded. Duplicate peer variants and no-op generated-file rewrites are handled without changing the template contract.
- No hook-disposal, external cancellation-timing, step-delivery, run-retention, or in-use adapter behavior change was listed.

## Temporary markers

No marker was resolved or retargeted. All nine occurrences pass the marker check.

- Keep the engine ceiling until the stable runtime declares engine 24 support.
- Keep the embedded data-directory override until local state resolves without it.
- Keep recovery disabled until restart cannot re-enqueue a pending paid step.
- Keep the internal manifest request until a public manifest command exists.

## Verification

External scratch used the candidate with the existing framework pin and a regenerated lockfile.

- Engine 22 deterministic suite: pass in 97.5 seconds.
- Forced engine 24 webhook-resume probe: pass in 95.6 seconds.
- Tracked-tree deterministic suite on engine 22 after the fixture gate: pass in 96.2 seconds.
- Fresh template install and check: pass with no version or managed-file warnings.
- Quality gates: core routing 24 of 24, hard routing 8 of 8, and nine markers pass.
- Repository layout and offline loader compatibility: pass.
- Diff whitespace check: pass.

The first remote template run exposed the fixture timing race described above. The branch now keeps the paid step open until the duplicate-run check completes. The engine ceiling remains unchanged because the stable-support removal condition has not been met.

Fixes #51