### PR TITLE
Document skill layers and refresh host contract to v11

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,32 @@
 
 Contributions should preserve one shared workspace contract and the authority boundaries in each skill. Open an issue before changing a public contract, persistent file shape, approval gate, or workflow-library version.
 
+## How the pieces relate
+
+The repo separates three layers, and every contribution should know which one it touches:
+
+- **Facts.** Company facts are workspace artifacts (`ORG.md`, ICPs, personas) in the company's own Git history, owned by lifecycle skills. Generic contracts are repo-shipped, company-free references (the shared company-data and person-data contracts; dated research snapshots under `docs/research`), owned by this repo and changed only through its review. If a sentence would differ between two companies, it is a company fact and belongs in the workspace, never in this repo.
+- **Methods.** The domain knowledge of GTM work, carried by skills. Methods stay generic and read company facts at use; they never contain any company's substance.
+- **Execution.** Two modes. A session carries one-off, judgment-heavy, human-attended work. A saved workflow carries recurring or at-volume work — including recurring or at-volume paid spend — with typed tables, committed migrations, the paid-call cache and ledger, dry runs, and pinned production commits. Workflows also produce data: their typed result tables are workflow-owned output that sessions may query read-only; results inform a durable fact only through a session editing the workspace artifact via its lifecycle skill, never through a workflow writing facts directly.
+
+Work moves between the execution modes in one direction. A method is proven in-session, where the human approves each one-off paid probe; it graduates to a workflow when it becomes recurring or at-volume — the tell is per-call approval turning into rubber-stamping. Graduation is per stage: mechanical stages (sourcing, enrichment, scoring) graduate while a genuinely per-item judgment stage stays attended in-session over the workflow's typed results, its accepted output re-entering as supplied rows, until sampled review honestly suffices.
+
+Knowledge crosses that boundary only at authoring time: the agent compiles a skill's method and the accepted workspace-artifact text into the workflow's committed `agent()` prompts (accepted ICP or persona text passed as `agent({ context, contextId })`, the `contextId` naming its source artifact). A workflow never loads, resolves, or fetches skill content at run time — a production run resolves no knowledge outside its reviewed commit. When the source method or artifact later changes, deployed workflows deliberately keep the text they were compiled with until a session recompiles them as a reviewed change.
+
+## Two skill species
+
+- A **lifecycle skill** (`gtm-workspace`, `gtm-icp`, `gtm-persona`, `gtm-workflow`) owns the full lifecycle of a durable artifact or project and carries the full SOP contract: trigger, scope, contract table, approval gates, and handoffs. Add one only when a genuinely new durable artifact type needs an owner.
+- A **domain skill** (future `gtm-*` work skills such as lead scoring or sequencing) does GTM work in a session using the facts layer. It never owns durable artifacts and never embeds its own runners, provider adapters, tables, caches, or ledgers; saved execution belongs to `gtm-workflow`.
+
+A domain skill is admitted when both hold: **generic** (no company-specific substance; the vendor swap test below applies to companies too) and **grounded** (the method consumes workspace artifacts or workflow result tables, not free-floating prompting).
+
+Domain skill anatomy:
+
+- One light `SKILL.md` wrapper written for interactive session use; it does not need the lifecycle contract table.
+- A standard graduation clause: when the work becomes recurring or at-volume, hand off to `gtm-workflow` and compile the method into the workflow's committed prompts.
+- `references/method.md` — the medium-neutral method: criteria, steps, and quality bars with no interaction assumptions — is split out of the wrapper at first graduation, not before. After the split the wrapper keeps zero method content, so the method has exactly one source.
+- Session paid calls: any skill session, lifecycle research included, makes a one-off paid probe only with explicit human approval per call and credentials under the secrets rules below. Recurring or at-volume spend graduates to a workflow, where every paid call is cached and ledgered.
+
 ## Hard rejects
 
 A contribution is rejected if it includes any of the following:

--- a/docs/gtm-agent-requirements.md
+++ b/docs/gtm-agent-requirements.md
@@ -1,6 +1,8 @@
-# GTM agent requirements for workflow v10
+# GTM agent requirements for workflow v11
 
-This is the host contract for a small Eve Slack agent that authors the v10 `gtm-workflow` project in one connected GTM workspace and runs it on Vercel. Vercel deploys the workflow project from that same repository. The sandbox never starts a real run.
+This is the host contract for a small Eve Slack agent that authors the v11 `gtm-workflow` project in one connected GTM workspace and runs it on Vercel. Vercel deploys the workflow project from that same repository. The sandbox never starts a real run.
+
+This contract tracks the workflow library major version: refresh it in the same reviewed change as every `gtm-lib` bump, so it never describes a project shape the skill no longer authors.
 
 ## What belongs in the reusable gtm-agent template
 


### PR DESCRIPTION
## Summary
- Adds "How the pieces relate" and "Two skill species" sections to CONTRIBUTING.md: the facts/methods/execution layer model, lifecycle vs domain skills, admission criteria (generic + grounded), domain-skill anatomy with the method.md-at-first-graduation rule, per-stage graduation from sessions to workflows, the compile-time-only knowledge rule (a workflow never resolves skill content at run time), and the per-call human approval rule for session paid probes.
- Updates docs/gtm-agent-requirements.md from workflow v10 to v11 (the skill templates already author gtm-lib v11) and adds the refresh rule: the host contract updates in the same reviewed change as every gtm-lib bump.

## Notes
- `docs/research/` is untracked locally and referenced by the new CONTRIBUTING text; it is deliberately not included here — commit it separately if it should ship.
- Docs-only change: no skill behavior, contract table, or version-record updates required.
- `python3 scripts/check_repo_layout.py` and `python3 scripts/check_skill_compatibility.py` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012SsBJoTEnmPR1iBuPLqdLV