### PR TITLE
Rename qualification skill and document skill types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## Unreleased, gtm-lib v11
 
-- Added `gtm-qualify`, the first domain skill, for bounded in-session qualification of people against personas and companies against ICPs with strict mode separation and no writes. Its authoring-time invariant places the numeric band mapping once, in Procedure.
+- Renamed the bounded qualification skill to `gtm-qualify-prospects` and classified it as the first Task Skill. It qualifies people against personas and companies against ICPs in session, with strict mode separation and no writes. Its authoring-time invariant places the numeric band mapping once, in Procedure.
 - Session paid calls now allow exact-scope batch approval that states entities, capability, call count, effect, and stateable cost or explicitly says cost is not stateable; recurring or at-volume spend still graduates to `gtm-workflow`.
-- ICP and persona descriptions now route saved-artifact qualification and scoring to `gtm-qualify`.
+- ICP and persona descriptions now route saved-artifact qualification and scoring to `gtm-qualify-prospects`.
 - New and fully researched member and persona artifacts now use the same eight-field person-data contract. Member email remains a separate supplied identifier and is never inferred.
 - New and fully researched organization and ICP artifacts now use the same 13-field company-data contract, with explicit unknowns and separate employee-range, employee-count, location, and tech-stack shapes.
 - GTM workspace creation can now skip member onboarding and continue directly to the sharing choice.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,19 +14,28 @@ Work moves between the execution modes in one direction. A method is proven in-s
 
 Knowledge crosses that boundary only at authoring time: the agent compiles a skill's method and the accepted workspace-artifact text into the workflow's committed `agent()` prompts (accepted ICP or persona text passed as `agent({ context, contextId })`, the `contextId` naming its source artifact). A workflow never loads, resolves, or fetches skill content at run time — a production run resolves no knowledge outside its reviewed commit. When the source method or artifact later changes, deployed workflows deliberately keep the text they were compiled with until a session recompiles them as a reviewed change.
 
-## Two skill species
+## Skill types
 
-- A **lifecycle skill** (`gtm-workspace`, `gtm-icp`, `gtm-persona`, `gtm-workflow`) owns the full lifecycle of a durable artifact or project and carries the full SOP contract: trigger, scope, contract table, approval gates, and handoffs. Add one only when a genuinely new durable artifact type needs an owner.
-- A **domain skill** (future `gtm-*` work skills such as lead scoring or sequencing) does GTM work in a session using the facts layer. It never owns durable artifacts and never embeds its own runners, provider adapters, tables, caches, or ledgers; saved execution belongs to `gtm-workflow`.
+| Type | Owns | Naming rule | Example |
+| --- | --- | --- | --- |
+| Artifact Skill | One output's required contents and acceptance criteria | Bare noun | `gtm-report` |
+| Process Skill | A recurring, cross-step process | Gerund | `gtm-reporting` |
+| Lifecycle Skill | One entity across creation, maintenance, and retirement | Bare noun naming the entity; never `-management` | `gtm-workspace` |
+| Task Skill | One bounded action | Imperative verb-noun | `gtm-qualify-prospects` |
+| Policy Skill | Declarative constraints, taste, or quality bars | Bare noun or plural | `gtm-writing` |
 
-A domain skill is admitted when both hold: **generic** (no company-specific substance; the vendor swap test below applies to companies too) and **grounded** (the method consumes workspace artifacts or workflow result tables, not free-floating prompting).
+Classify a skill by what it owns, not by incidental verbs in its prose. A Task Skill's noun takes the number the task operates on per invocation: one CRM becomes `gtm-clean-crm`, while a batch of rows becomes `gtm-qualify-prospects`. A Task Skill does its task in session when viable. When the task recurs or runs at volume, it builds a workflow through `gtm-workflow` and still does the task. Where that boundary sits is a property of the task, not a different type.
 
-Domain skill anatomy:
+The current Lifecycle Skills are `gtm-workspace`, `gtm-icp`, `gtm-persona`, and `gtm-workflow`. Each owns the full lifecycle of a durable artifact or project and carries the full Skill contract: trigger, scope, contract table, approval gates, and handoffs. Add a Lifecycle Skill only when a genuinely new durable artifact type needs an owner. The current Task Skill is `gtm-qualify-prospects`.
 
-- One light `SKILL.md` wrapper written for interactive session use; it does not need the lifecycle contract table.
-- A standard graduation clause: when the work becomes recurring or at-volume, hand off to `gtm-workflow` and compile the method into the workflow's committed prompts.
-- `references/method.md` — the medium-neutral method: criteria, steps, and quality bars with no interaction assumptions — is split out of the wrapper at first graduation, not before. After the split the wrapper keeps zero method content, so the method has exactly one source.
-- Session paid calls: any skill session, lifecycle research included, makes paid calls only with explicit human approval per call, or one exact-scope gate per batch that names the entities, provider capability, call count, effect, and the cost the session can state (unit and total, or credits) or explicitly states that cost is not stateable from the session's tooling. Credentials remain under the secrets rules below. Recurring or at-volume spend graduates to a workflow, where every paid call is cached and ledgered.
+Non-lifecycle skills, primarily Task Skills, are admitted when both conditions hold: **generic** means no company-specific substance, with the vendor swap test below applying to companies too; **grounded** means the method consumes workspace artifacts or workflow result tables rather than free-floating prompting. They do not own durable artifacts or embed their own runners, provider adapters, tables, caches, or ledgers. Saved execution belongs to `gtm-workflow`.
+
+Non-lifecycle skill anatomy:
+
+- One light `SKILL.md` wrapper written for interactive session use; it does not need the Lifecycle Skill contract table.
+- A standard graduation clause: when the work becomes recurring or at volume, hand off to `gtm-workflow` and compile the method into the workflow's committed prompts.
+- `references/method.md` holds the medium-neutral method: criteria, steps, and quality bars with no interaction assumptions. Split it out of the wrapper at first graduation, not before. After the split, the wrapper keeps zero method content, so the method has exactly one source.
+- Any skill session, including Lifecycle Skill research, makes paid calls only with explicit human approval per call, or one exact-scope gate per batch that names the entities, provider capability, call count, effect, and the cost the session can state (unit and total, or credits) or explicitly states that cost is not stateable from the session's tooling. Credentials remain under the secrets rules below. Recurring or at-volume spend graduates to a workflow, where every paid call is cached and ledgered.
 
 ## Hard rejects
 

--- a/README.md
+++ b/README.md
@@ -67,18 +67,18 @@ The GTM workspace records durable facts about the business and its team. ICPs de
 | **Production refuses to run a commit other than the accepted commit** | ✅ | ❌ | ❌ | ❌ |
 | **The same workflow file runs locally or in a hosted deployment** | ✅ | ❌ | ❌ | ❌ |
 
-Keep durable GTM knowledge and reusable automations in one repository. Each SOP reads only the artifacts visible to the selected organization node and preserves accepted durable changes in history.
+Keep durable GTM knowledge and reusable automations in one repository. Each skill reads only the artifacts visible to the selected organization node and preserves accepted durable changes in history.
 
 ## How the five skills fit together
 
-Four lifecycle skills form one chain of durable ownership; one domain skill performs bounded in-session work from their shared facts. They resolve the same organization node, while durable changes use the same review-before-write rule and Git history.
+Four Lifecycle Skills form one chain of durable ownership; one Task Skill performs bounded in-session work from their shared facts. They resolve the same organization node, while durable changes use the same review-before-write rule and Git history.
 
 | Skill | Owns | Hands off |
 | --- | --- | --- |
 | `gtm-workspace` | Organization structure, members, repository health, and connections | The selected organization node and its visible files |
 | `gtm-icp` | The companies that node serves, including disqualifiers and uncertainty | An accepted market definition at a stable path |
 | `gtm-persona` | The buyers and stakeholders that node needs to understand | An accepted buyer definition at a stable path |
-| `gtm-qualify` | In-session person-to-persona and company-to-ICP fit qualification | Per-row fit verdicts in the conversation |
+| `gtm-qualify-prospects` | In-session person-to-persona and company-to-ICP fit qualification | Per-row fit verdicts in the conversation |
 | `gtm-workflow` | Typed workflow code, migrations, runs, results, cache entries, and costs | Database-backed outcomes tied to the accepted workspace context |
 
 Project records: [versions and compatibility](VERSIONS.md) · [changelog](CHANGELOG.md) · [security policy](SECURITY.md) · [contribution rules](CONTRIBUTING.md)
@@ -115,7 +115,7 @@ No. The agent writes the workflow code and migrations. You review the complete t
 
 ### What gets installed?
 
-The install command adds GTM Workspace, GTM ICP, GTM Persona, GTM Qualify, and GTM Workflow. Run `/gtm-workspace` first, use `/gtm-icp` and `/gtm-persona` for the definitions your organization owns, `/gtm-qualify` for bounded in-session fit checks, and `/gtm-workflow` for reusable automations.
+The install command adds GTM Workspace, GTM ICP, GTM Persona, GTM Qualify Prospects, and GTM Workflow. Run `/gtm-workspace` first, use `/gtm-icp` and `/gtm-persona` for the definitions your organization owns, `/gtm-qualify-prospects` for bounded in-session fit checks, and `/gtm-workflow` for reusable automations.
 
 ### What does GTM Workspace store?
 

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,13 +1,13 @@
 # Versions and compatibility
 
-This table is the public version record for five installable skills: four lifecycle skills and one domain skill. Version `1.0.0` is the first tracked public-contract version for each skill. Earlier behavior remains visible in Git history.
+This table is the public version record for five installable skills: four Lifecycle Skills and one Task Skill. Version `1.0.0` is the first tracked public-contract version for each skill. Earlier behavior remains visible in Git history.
 
 | Skill | Skill version | Last behavior change | Purpose | Shipped library | Exercised loaders | Checked |
 | --- | --- | --- | --- | --- | --- | --- |
 | `gtm-workspace` | 1.3.0 | 2026-08-30 | Creates, imports, maintains, and repairs the shared organization workspace | None | Shared `.agents/skills` loader; project `.claude/skills` loader | 2026-08-30 |
 | `gtm-icp` | 1.1.0 | 2026-08-30 | Owns node-local ideal customer profile creation, revision, deletion, and repair | None | Shared `.agents/skills` loader; project `.claude/skills` loader | 2026-08-30 |
 | `gtm-persona` | 1.1.0 | 2026-08-30 | Owns node-local buyer and stakeholder persona creation, revision, deletion, and repair | None | Shared `.agents/skills` loader; project `.claude/skills` loader | 2026-08-30 |
-| `gtm-qualify` | 1.0.0 | 2026-09-01 | Qualifies supplied people against saved personas and companies against saved ICPs | None | Shared `.agents/skills` loader; project `.claude/skills` loader | 2026-09-01 |
+| `gtm-qualify-prospects` | 1.0.0 | 2026-09-01 | Qualifies supplied people against saved personas and companies against saved ICPs | None | Shared `.agents/skills` loader; project `.claude/skills` loader | 2026-09-01 |
 | `gtm-workflow` | 1.0.0 | 2026-08-28 | Authors and runs typed, migrated workflows with cache, cost, approval, and deployment controls | `gtm-lib` v10 | Shared `.agents/skills` loader; project `.claude/skills` loader | 2026-08-28 |
 
 The offline compatibility check copies all five skills into both loader directory shapes, parses every `SKILL.md`, validates the common Contract fields and shared data contracts, and resolves each local reference. Run it with:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,6 +1,6 @@
 # Getting started: build your GTM foundation
 
-GTM Skills gives your AI agent five focused SOPs—four lifecycle skills and one domain skill—that share one Git-backed source of truth. This guide takes you from installation to a GTM workspace with its first ICP, persona, and reusable workflow: the agent writes the code, and you review one diff and one dry run.
+GTM Skills gives your AI agent five focused skills: four Lifecycle Skills and one Task Skill. They share one Git-backed source of truth. This guide takes you from installation to a GTM workspace with its first ICP, persona, and reusable workflow: the agent writes the code, and you review one diff and one dry run.
 
 ## 1. Check the prerequisites
 
@@ -19,7 +19,7 @@ Install all five skills globally:
 npx skills add eliasstravik/gtm-skills -g
 ```
 
-Your agent can now use GTM Workspace, GTM ICP, GTM Persona, GTM Qualify, and GTM Workflow.
+Your agent can now use GTM Workspace, GTM ICP, GTM Persona, GTM Qualify Prospects, and GTM Workflow.
 
 ## 3. Build your GTM workspace
 
@@ -137,7 +137,7 @@ Use the same five skills as the organization evolves:
 - Run `/gtm-workspace` to update organization facts or members, add suborganizations, or validate and repair the repository.
 - Run `/gtm-icp` to create, refine, delete, or doctor an ICP.
 - Run `/gtm-persona` to create, refine, delete, or doctor a persona.
-- Run `/gtm-qualify` to qualify supplied people against saved personas and companies against saved ICPs in-session.
+- Run `/gtm-qualify-prospects` to qualify supplied people against saved personas and companies against saved ICPs in-session.
 - Run `/gtm-workflow` to create, update, inspect, delete, or run a saved workflow.
 
 Every accepted change is saved to Git history so it can be reviewed and recovered.

--- a/skills/gtm-qualify-prospects/SKILL.md
+++ b/skills/gtm-qualify-prospects/SKILL.md
@@ -1,13 +1,13 @@
 ---
-name: gtm-qualify
-description: Triggers when a user asks to qualify, score, or fit-check supplied leads, accounts, contacts, people, or companies against a connected GTM workspace's saved ICPs or personas, including "is X a fit for us" requests. Not for creating or editing ICPs or personas, saved or scheduled scoring at volume (use gtm-workflow), intent or engagement scoring, or workspace repair.
+name: gtm-qualify-prospects
+description: Triggers when a user asks to qualify, score, or fit-check supplied leads, accounts, contacts, people, or companies in either supported mode, people against a connected GTM workspace's saved personas or companies against its saved ICPs. Includes "is X a fit for us" requests. Not for creating or editing ICPs or personas, saved or scheduled scoring at volume (use gtm-workflow), intent or engagement scoring, or workspace repair.
 ---
 
-# GTM Qualify
+# GTM Qualify Prospects
 
 ## Trigger
 
-Apply this Task SOP when the user supplies one or more people or companies to qualify against the connected workspace's saved personas or ICPs.
+Apply this Task Skill when the user supplies one or more people or companies to qualify against the connected workspace's saved personas or ICPs.
 
 ## Scope
 
@@ -18,7 +18,7 @@ Own one bounded, in-session qualification action in two strictly separated modes
 | Field | Public contract |
 | --- | --- |
 | Reads | Supplied identifiers and rows, visible ICP and persona files, the shared company/person data contracts, free public research scoped to matched-artifact criteria, and gate-approved paid identity and enrichment calls |
-| Writes | Nothing; any post-SOP file the user requests is ordinary session work outside this contract, and never a file inside the workspace repo |
+| Writes | Nothing; any post-skill file the user requests is ordinary session work outside this contract, and never a file inside the workspace repo |
 | Outputs | Per-row fit verdicts (reasoning ending in a band sentence; confidence · verdict · score) in the conversation; reasoning-only rows for Insufficient Data and No Matching Persona/ICP |
 | Approval | Exact-scope gates per batch of paid calls — identity, then enrichment — each naming entities, capability, call count, effect, and stateable cost or not-stateable |
 | Persists | Nothing; results live in the conversation |


### PR DESCRIPTION
Summary
- rename the qualification skill and all public references to gtm-qualify-prospects
- replace the two-species contribution model with the five Skill types
- retain the existing admission, graduation, and paid-call rules for non-lifecycle skills

Checks
- python3 scripts/check_repo_layout.py
- python3 scripts/check_skill_compatibility.py

Fixes #63