### PR TITLE
Release 0.1.0 under one project version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
-## Unreleased, gtm-lib v11
+## 0.1.0, 2026-09-01
+
+First release under one project version. Earlier per-skill versions and `gtm-lib-v<generation>` tags are superseded; this release ships workflow library generation 11.
 
 - Renamed the bounded qualification skill to `gtm-qualify-prospects` and classified it as the first Task Skill. It qualifies people against personas and companies against ICPs in session, with strict mode separation and no writes. Its authoring-time invariant places the numeric band mapping once, in Procedure.
 - Session paid calls now allow exact-scope batch approval that states entities, capability, call count, effect, and stateable cost or explicitly says cost is not stateable; recurring or at-volume spend still graduates to `gtm-workflow`.
@@ -10,7 +12,7 @@
 - GTM workspace creation can now skip member onboarding and continue directly to the sharing choice.
 - Updated the pinned workflow runtime from beta.44 to beta.46 after the template suite passed on engine 22 and the forced webhook-resume probe passed on engine 24. The engine ceiling stays unchanged until the stable runtime declares support.
 
-## gtm-lib v10, 2026-08-28
+## Before 0.1.0: gtm-lib v10, 2026-08-28
 
 - Cloud inspection now requires a read-only credential and rejects data-changing statements, including writes hidden behind a common table expression.
 - Untrusted workflow content reaches only model backends that can disable tools. Accepted ICP and persona content now participates in the model cache key.
@@ -21,17 +23,18 @@
 - Production starts require the exact accepted workspace commit. Missing, dirty, unpushed, or mismatched commits stop before a real run.
 - Shared row execution now owns spend caps, checkpoint behavior, per-row failures, honest terminal states, remaining keys, and final bookkeeping.
 
-## gtm-lib v9, 2026-08-27
+## Before 0.1.0: gtm-lib v9, 2026-08-27
 
 - Preserved original provider responses for cache reparsing.
 - Restored the local workflow runtime and made the paid-call ledger authoritative for run totals.
 
 ## Upgrade notes for older projects
 
-| Installed library | User-visible reason to upgrade to v10 |
+| Installed library generation | User-visible reason to upgrade to generation 11 |
 | --- | --- |
 | v2 | No fixed workflow schema or committed migration path |
 | v5 | No supported run cancellation |
 | v6 | Web research evidence can be separated from the structured answer that needs it |
 | v8 | Cached provider responses cannot be reparsed from the original payload, and run totals can diverge from the ledger |
 | v9 | Read-only inspection, tool isolation, duplicate-run protection, context-aware caching, redaction, cost attribution, approval reuse, restart safety, and exact-commit starts are incomplete |
+| v10 | No provider discovery, bounded operator polling, row and step ledger attribution, selective reruns, command-generated diagrams, or receipt summaries |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,7 @@ For every vendor mention outside a skill file, replace the vendor mentally with 
 
 - Keep the change inside one declared scope and update the public contract when reads, writes, outputs, approvals, persistence, or handoffs change.
 - Add or update deterministic checks for changed behavior. Tests must not use live credentials, paid calls, or production endpoints.
-- Update [VERSIONS.md](VERSIONS.md) and [CHANGELOG.md](CHANGELOG.md) when behavior changes. A workflow-library bump also requires the release tag described in `VERSIONS.md`.
+- Update [VERSIONS.md](VERSIONS.md) and [CHANGELOG.md](CHANGELOG.md) when behavior changes. Every release requires the project tag described in `VERSIONS.md`; a managed workflow-file change also bumps the library generation.
 - Run `python3 scripts/check_repo_layout.py` and `python3 scripts/check_skill_compatibility.py`. When workflow files change, also run `node --test evals/gtm-workflow/scripts/test-templates.mjs`.
 - Review the staged diff for secret values, unrelated files, remote-code execution, and missing human gates.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -26,4 +26,4 @@ Redaction is a fallback, not a storage mechanism for secrets. Adapters should th
 
 ## Supported versions
 
-The current skill and workflow-library versions are listed in [VERSIONS.md](VERSIONS.md). Security fixes target the current release. Upgrade older workflow projects through the skill's reviewed recopy and migration path.
+The current project version and workflow library generation are listed in [VERSIONS.md](VERSIONS.md). Security fixes target the current release. Upgrade older workflow projects through the skill's reviewed recopy and migration path.

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,14 +1,15 @@
 # Versions and compatibility
 
-This table is the public version record for five installable skills: four Lifecycle Skills and one Task Skill. Version `1.0.0` is the first tracked public-contract version for each skill. Earlier behavior remains visible in Git history.
+GTM Skills has one project version. Every installable skill ships at that version, and the release tag is `v<version>` on the reviewed `main` commit.
 
-| Skill | Skill version | Last behavior change | Purpose | Shipped library | Exercised loaders | Checked |
-| --- | --- | --- | --- | --- | --- | --- |
-| `gtm-workspace` | 1.3.0 | 2026-08-30 | Creates, imports, maintains, and repairs the shared organization workspace | None | Shared `.agents/skills` loader; project `.claude/skills` loader | 2026-08-30 |
-| `gtm-icp` | 1.1.0 | 2026-08-30 | Owns node-local ideal customer profile creation, revision, deletion, and repair | None | Shared `.agents/skills` loader; project `.claude/skills` loader | 2026-08-30 |
-| `gtm-persona` | 1.1.0 | 2026-08-30 | Owns node-local buyer and stakeholder persona creation, revision, deletion, and repair | None | Shared `.agents/skills` loader; project `.claude/skills` loader | 2026-08-30 |
-| `gtm-qualify-prospects` | 1.0.0 | 2026-09-01 | Qualifies supplied people against saved personas and companies against saved ICPs | None | Shared `.agents/skills` loader; project `.claude/skills` loader | 2026-09-01 |
-| `gtm-workflow` | 1.0.0 | 2026-08-28 | Authors and runs typed, migrated workflows with cache, cost, approval, and deployment controls | `gtm-lib` v10 | Shared `.agents/skills` loader; project `.claude/skills` loader | 2026-08-28 |
+| Project version | Released | Skills | Workflow library generation | Checked |
+| --- | --- | --- | --- | --- |
+| 0.1.0 | 2026-09-01 | `gtm-workspace`, `gtm-icp`, `gtm-persona`, `gtm-qualify-prospects`, `gtm-workflow` | 11 | 2026-09-01 |
+
+## What each number means
+
+- **Project version** is the only version to track. It covers all five skills, their references, and the workflow templates as one release. Downstream hosts such as `gtm-agent` vendor the tagged commit.
+- **Workflow library generation** is an internal compatibility marker for the managed workflow files. It appears as the `// gtm-lib v11` header, `gtm.libVersion` in the template `package.json`, and the content hashes under `gtm.libHashes`. `gtm check` compares a project against it and offers a recopy when headers or hashes differ. It increments only when a managed file changes; it is not a version to install or announce.
 
 The offline compatibility check copies all five skills into both loader directory shapes, parses every `SKILL.md`, validates the common Contract fields and shared data contracts, and resolves each local reference. Run it with:
 
@@ -16,14 +17,10 @@ The offline compatibility check copies all five skills into both loader director
 python3 scripts/check_skill_compatibility.py
 ```
 
-## Release tags
+## Release procedure
 
-The current workflow library release is `gtm-lib-v10`. The tag points to the first reviewed `main` commit that contains the complete v10 library and its migration.
-
-For every future workflow-library bump:
-
-1. Update every managed header, content hash, migration, workflow contract, this table, and [CHANGELOG.md](CHANGELOG.md) in the reviewed change.
+1. Update this table and [CHANGELOG.md](CHANGELOG.md) in the reviewed change. When managed workflow files change, also bump the library generation, every managed header, `gtm.libVersion`, and `gtm.libHashes`.
 2. Merge the change to `main`.
-3. Create the annotated tag `gtm-lib-v<version>` on that merge commit and push the tag.
+3. Create the annotated tag `v<version>` on that merge commit and push the tag.
 
-Skill versions change only when the corresponding `SKILL.md` public behavior changes. Documentation corrections that do not change reads, writes, outputs, approvals, persistence, or handoffs do not require a skill-version bump.
+Earlier releases used per-skill versions and `gtm-lib-v<generation>` tags. The `gtm-lib-v10` tag remains in history; new releases use project tags only.


### PR DESCRIPTION
## Summary
- Replace per-skill semver and `gtm-lib-v<generation>` tags with one project version, `0.1.0`, tagged `v0.1.0`.
- Keep the `gtm-lib v11` header and `gtm.libVersion` as an internal managed-file generation marker, documented as such.
- Move the unreleased v11 changelog section under `0.1.0` and add the v10 upgrade row.

## Verification
- `python3 scripts/check_repo_layout.py`
- `python3 scripts/check_skill_compatibility.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AesT344USTB9oLVts251F2