### PR TITLE
Allow only the gate or a numbered block to ask for a decision (0.3.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.3.2, 2026-09-09
+
+Workflow library generation 13, unchanged.
+
+- The shared interaction standard now names the only two ways to ask for a decision: the gate (native approval control, or the numbered `Save this?` block on a keyboard) for any durable action, and a numbered choice block with option 1 `(Recommended)` for everything else. Open questions are for typed facts only. Yes-or-no questions, `Shall I…?`, and invented confirmation phrases such as `Say "add them"` are banned.
+- Once a proposal's facts are in hand, the next assistant action is the gate. No readiness or research-complete message precedes it.
+- Validation used the offline repository and compatibility checks only; no eval was run or updated for this release.
+
 ## 0.3.1, 2026-09-09
 
 Workflow library generation 13, unchanged.

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -4,6 +4,7 @@ GTM Skills has one project version. Every installable skill ships at that versio
 
 | Project version | Released | Skills | Workflow library generation | Checked |
 | --- | --- | --- | --- | --- |
+| 0.3.2 | 2026-09-09 | `gtm-workspace`, `gtm-icp`, `gtm-persona`, `gtm-qualify-prospects`, `gtm-workflow` | 13 | 2026-09-09 |
 | 0.3.1 | 2026-09-09 | `gtm-workspace`, `gtm-icp`, `gtm-persona`, `gtm-qualify-prospects`, `gtm-workflow` | 13 | 2026-09-09 |
 | 0.3.0 | 2026-09-08 | `gtm-workspace`, `gtm-icp`, `gtm-persona`, `gtm-qualify-prospects`, `gtm-workflow` | 13 | 2026-09-08 |
 | 0.2.1 | 2026-09-05 | `gtm-workspace`, `gtm-icp`, `gtm-persona`, `gtm-qualify-prospects`, `gtm-workflow` | 13 | 2026-09-05 |

--- a/skills/gtm-workspace/references/interaction.md
+++ b/skills/gtm-workspace/references/interaction.md
@@ -65,6 +65,15 @@ Splitting follows artifact boundaries only: ICPs, personas, members, and suborga
 
 ## Questions
 
+There are exactly two ways to ask the user for a decision, and the skill never invents a third:
+
+1. **A gate** for any durable action: the native approval control on a hosted surface, or the numbered `Save this?` block on a keyboard, per [Approval by surface](#approval-by-surface). Approve or 1 executes; Cancel or 3 writes nothing and the skill asks `**What would you like me to change?**`.
+2. **A numbered choice block** for every other decision, with option 1 the skill's recommendation ending `(Recommended)`.
+
+An open question is only for a fact the user must type (a name, an email, a URL). Never ask a yes-or-no question, never ask `Shall I…?` or `Should I proceed?`, and never define a confirmation phrase such as `Say "add them"` or `Reply yes to continue`. The user's only ways to say yes are the gate and a number.
+
+Once every fact a proposal needs is in hand, the next assistant action is the gate itself. No message announces that research is complete, that drafts are ready, or what the proposal will contain; the proposal is that announcement.
+
 Ask only for a missing decision or fact that changes the result. Put every such question in one message: one bold lead question first, then the remaining facts wanted as a bulleted list (never numbered), each on one line with a fictional example where the flow already has one. At most one numbered choice block per message; only choice options are numbered, at most option 1 ends with `(Recommended)`, and the block ends exactly `Reply with a number, or type your answer.` A message with no choice block has no reply line.
 
 Do not ask for facts the agent can research or leave as `Unknown`. Do not use `AskUserQuestion` or a host question tool.


### PR DESCRIPTION
## Summary

Release 0.3.2. A hosted agent wrote "Research is complete and the three ICP drafts are ready… Say “add them” and I’ll send the save approval." That is a third decision surface the standard never defined. The shared interaction standard's Questions section now states:

- There are exactly two ways to ask for a decision: **the gate** (native approval control, or the numbered `Save this?` block on a keyboard) for any durable action, and **a numbered choice block** with option 1 `(Recommended)` for everything else.
- An open question is only for a typed fact. Yes-or-no questions, `Shall I…?`, and invented confirmation phrases (`Say "add them"`, `Reply yes to continue`) are banned.
- Once a proposal's facts are in hand, the next assistant action is the gate itself. No readiness or research-complete message precedes it.

`CHANGELOG.md` and `VERSIONS.md` updated. Workflow library generation stays 13. No template file changed, so downstream workspaces need nothing.

## Verification

```
python3 scripts/check_repo_layout.py
Repository layout is valid: 5 installable skill(s), evals outside skills/.
python3 scripts/check_skill_compatibility.py
Skill compatibility is valid: 5 skills across 2 offline loader shapes.
```

No eval was run or updated, by request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EJwZDZJxk71TPQLWTMMspX
