### PR TITLE
Fix duplicate hosted workflow link blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.4.3, 2026-09-09
+
+Workflow library generation 16, unchanged.
+
+- When a hosted channel sends the workflow picture and Diagram/Runs/Data links, the assistant adds only a caption instead of repeating the links.
+- Validation used offline repository and compatibility checks. Evals were skipped at the user’s request.
+
 ## 0.4.2, 2026-09-09
 
 Workflow library generation 16.

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -4,6 +4,7 @@ GTM Skills has one project version. Every installable skill ships at that versio
 
 | Project version | Released | Skills | Workflow library generation | Checked |
 | --- | --- | --- | --- | --- |
+| 0.4.3 | 2026-09-09 | `gtm-workspace`, `gtm-icp`, `gtm-persona`, `gtm-qualify-prospects`, `gtm-workflow` | 16 | 2026-09-09 |
 | 0.4.2 | 2026-09-09 | `gtm-workspace`, `gtm-icp`, `gtm-persona`, `gtm-qualify-prospects`, `gtm-workflow` | 16 | 2026-09-09 |
 | 0.4.1 | 2026-09-09 | `gtm-workspace`, `gtm-icp`, `gtm-persona`, `gtm-qualify-prospects`, `gtm-workflow` | 15 | 2026-09-09 |
 | 0.4.0 | 2026-09-09 | `gtm-workspace`, `gtm-icp`, `gtm-persona`, `gtm-qualify-prospects`, `gtm-workflow` | 14 | 2026-09-09 |

--- a/skills/gtm-workflow/references/conversation.md
+++ b/skills/gtm-workflow/references/conversation.md
@@ -73,6 +73,8 @@ Add a short caption with the trigger, inputs or changes, saved result, and parti
 
 ## Where to look
 
+When a host channel automatically delivers the picture and the Diagram/Runs/Data block together, that message fulfills this section. Add only a short workflow caption; do not repeat the links or add another block. For a links-only request, the channel message needs no additional reply.
+
 After a workflow is resolved, the flows in [flows](flows.md#where-to-look-moments) show one block of at most three lines:
 
 ```text


### PR DESCRIPTION
Hosted channels already deliver the workflow picture and Diagram/Runs/Data links, but the skill also asks the assistant to repeat the block. Treat the channel message as fulfillment of that requirement, with only an optional caption from the assistant.

Release 0.4.3; workflow library remains generation 16. Offline layout and compatibility checks passed. No evals were run; CI is skipped for this release at the user’s request.

Closes #78.
