### PR TITLE
Combine hosted workflow captions with the diagram message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.4.4, 2026-09-09
+
+Workflow library generation 16, unchanged.
+
+- Hosted workflow diagrams combine the caption, picture, and links into one message instead of posting the caption separately.
+- Validation used offline repository and compatibility checks. Evals were skipped at the user’s request.
+
 ## 0.4.3, 2026-09-09
 
 Workflow library generation 16, unchanged.

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -4,6 +4,7 @@ GTM Skills has one project version. Every installable skill ships at that versio
 
 | Project version | Released | Skills | Workflow library generation | Checked |
 | --- | --- | --- | --- | --- |
+| 0.4.4 | 2026-09-09 | `gtm-workspace`, `gtm-icp`, `gtm-persona`, `gtm-qualify-prospects`, `gtm-workflow` | 16 | 2026-09-09 |
 | 0.4.3 | 2026-09-09 | `gtm-workspace`, `gtm-icp`, `gtm-persona`, `gtm-qualify-prospects`, `gtm-workflow` | 16 | 2026-09-09 |
 | 0.4.2 | 2026-09-09 | `gtm-workspace`, `gtm-icp`, `gtm-persona`, `gtm-qualify-prospects`, `gtm-workflow` | 16 | 2026-09-09 |
 | 0.4.1 | 2026-09-09 | `gtm-workspace`, `gtm-icp`, `gtm-persona`, `gtm-qualify-prospects`, `gtm-workflow` | 15 | 2026-09-09 |

--- a/skills/gtm-workflow/references/conversation.md
+++ b/skills/gtm-workflow/references/conversation.md
@@ -73,7 +73,7 @@ Add a short caption with the trigger, inputs or changes, saved result, and parti
 
 ## Where to look
 
-When a host channel automatically delivers the picture and the Diagram/Runs/Data block together, that message fulfills this section. Add only a short workflow caption; do not repeat the links or add another block. For a links-only request, the channel message needs no additional reply.
+When a host channel combines the final caption, picture, and Diagram/Runs/Data block into one message, that message fulfills this section. Supply only a short workflow caption for the host to include; do not repeat the links or add another block. For a links-only request, the channel message needs no caption.
 
 After a workflow is resolved, the flows in [flows](flows.md#where-to-look-moments) show one block of at most three lines:
 


### PR DESCRIPTION
A hosted diagram currently leaves its caption in a second message. Specify that the host combines the final caption, picture, and Diagram/Runs/Data block into one message. Release 0.4.4; workflow library generation 16 is unchanged.

Offline layout and compatibility checks passed. No evals; CI skipped at the user’s request.

Closes #80.
