### PR TITLE
Replace the lockfile on upgrade so Linux builds keep their native bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- `gtm upgrade` also replaces `package-lock.json` from the template. Merging dependencies and regenerating the lockfile locally could drop every platform-specific optional package, after which the Vercel build failed with `Cannot find module '@swc/core-linux-x64-gnu'`.
+
 ## 1.0.2 - 2026-09-11
 
 - A database connection failure during the startup migration is retried on the next request instead of being cached for the life of the server instance.

--- a/skills/gtm-workflow/templates/lib/cli-helpers.ts
+++ b/skills/gtm-workflow/templates/lib/cli-helpers.ts
@@ -19,3 +19,6 @@ export function pendingFrom(files: { file: string; hash: string }[], applied: Se
 export function backgroundArgv(args: string[]): string[] {
   return args.filter((value) => value !== "--background");
 }
+
+/** Paths `gtm upgrade` replaces from the template. The lockfile is authored content: a regenerated one can drop the platform binaries Linux builds need. */
+export const UPGRADE_REPLACES = ["lib", "server", "scripts", "nitro.config.ts", "drizzle.config.ts", "package-lock.json"] as const;

--- a/skills/gtm-workflow/templates/scripts/gtm.ts
+++ b/skills/gtm-workflow/templates/scripts/gtm.ts
@@ -6,7 +6,7 @@ import { createServer } from "node:net";
 import { basename, join, relative, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 import { executeReadOnly, ensureMigrated, readAppliedMigrationHashes } from "../lib/db";
-import { HELP, backgroundArgv, pendingFrom } from "../lib/cli-helpers";
+import { HELP, UPGRADE_REPLACES, backgroundArgv, pendingFrom } from "../lib/cli-helpers";
 import { ensureRunSecret } from "../lib/local-env";
 import { diagramCost, parseDiagramSpec } from "../lib/diagram-spec";
 import { overlayRun } from "../lib/diagram-overlay";
@@ -124,8 +124,8 @@ async function upgrade(args: string[]) {
   const { positionals, flags } = parse(args), ref = positionals[0] ?? "main"; const temporary = await mkdtemp(join(root, ".gtm-upgrade-"));
   await command("curl", ["-fsSL", `https://github.com/eliasstravik/gtm-skills/archive/${ref}.tar.gz`, "-o", join(temporary, "skills.tgz")]); await command("tar", ["-xzf", join(temporary, "skills.tgz"), "-C", temporary]);
   const sourceRoot = (await walk(temporary, (path) => path.endsWith("/skills/gtm-workflow/templates/package.json")))[0]?.replace(/\/package\.json$/, ""); if (!sourceRoot) throw new AppError("upgrade_failed", "The release does not contain the workflow template.");
-  if (!flags.yes) return print({ ref, replaces: ["lib", "server", "scripts", "nitro.config.ts", "drizzle.config.ts"], preserves: ["workflows", "db/tables", "providers", "drizzle", "data", ".env"] });
-  for (const path of ["lib", "server", "scripts", "nitro.config.ts", "drizzle.config.ts"]) await cp(join(sourceRoot, path), join(root, path), { recursive: true, force: true });
+  if (!flags.yes) return print({ ref, replaces: UPGRADE_REPLACES, preserves: ["workflows", "db/tables", "providers", "drizzle", "data", ".env"] });
+  for (const path of UPGRADE_REPLACES) await cp(join(sourceRoot, path), join(root, path), { recursive: true, force: true });
   const current = JSON.parse(await readFile(join(root, "package.json"), "utf8")), next = JSON.parse(await readFile(join(sourceRoot, "package.json"), "utf8")); current.dependencies = { ...current.dependencies, ...next.dependencies }; current.devDependencies = { ...current.devDependencies, ...next.devDependencies }; current.gtm = { ...(current.gtm ?? {}), skillsRelease: ref }; await writeFile(join(root, "package.json"), `${JSON.stringify(current, null, 2)}\n`); process.stdout.write("Run npm ci.\n");
 }
 

--- a/tests/cli-helpers.test.mjs
+++ b/tests/cli-helpers.test.mjs
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { HELP, backgroundArgv, pendingFrom } from '../skills/gtm-workflow/templates/lib/cli-helpers.ts';
+import { HELP, UPGRADE_REPLACES, backgroundArgv, pendingFrom } from '../skills/gtm-workflow/templates/lib/cli-helpers.ts';
 
 test('pending migrations are the files whose hash is not in the ledger', () => {
   const files = [{ file: 'drizzle/0000_a.sql', hash: 'h1' }, { file: 'drizzle/0001_b.sql', hash: 'h2' }];
@@ -19,4 +19,9 @@ test('help lists every flag and diagram format', () => {
   for (const item of ['--dry-run', '--wait-live', '--background', '--checkpoint', '--url', '--wait', '--format', '--yes', '--sql', 'json', 'svg', 'png', 'web', 'markdown', 'csv', 'upgrade', 'help']) {
     assert.ok(HELP.includes(item), `help should mention ${item}`);
   }
+});
+
+test('upgrade replaces the template lockfile so a regenerated one cannot drop platform binaries', () => {
+  assert.ok(UPGRADE_REPLACES.includes('package-lock.json'));
+  assert.ok(!UPGRADE_REPLACES.includes('package.json'), 'package.json is merged, not replaced');
 });


### PR DESCRIPTION
## Why

Three consecutive production builds of `gtm-eliasstravik-workflows` failed today with `Cannot find module '@swc/core-linux-x64-gnu'`. The 1.0.0 upgrade commit there landed a regenerated `workflows/package-lock.json` with 531 packages instead of 684: every platform-specific optional package was gone. `gtm-notably` kept the template lockfile and never failed. The workspace was fixed by copying the template lockfile back by hand.

`gtm upgrade` replaces `lib`, `server`, `scripts`, and the two config files, merges dependency pins into `package.json`, and prints `Run npm ci.` Once pins change, `npm ci` rejects the stale lockfile, so the operator regenerates it locally, which is where the optional packages get lost.

## What

- `UPGRADE_REPLACES` in `lib/cli-helpers.ts` now includes `package-lock.json`, and `gtm upgrade` uses that list for both the dry-run report and the copy. `package.json` is still merged, not replaced.
- Changelog entry under Unreleased.

## Verified

- Template unit tests: 127 pass (CI invocation).
- `tsc --noEmit` over `scripts/gtm.ts` and `lib/cli-helpers.ts`: clean.
- The template and both workspaces pin identical dependencies, so the copied lockfile matches `npm ci`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014qiVGRPcpUq6XbE1SNpXC7