### PR TITLE
Restore the routing exclusion phrases and release 1.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
-## Unreleased
+## 1.0.3 - 2026-09-11
 
+- The `gtm-workflow` description names other workflow engines and unsaved one-off calls in its exclusion clause again, and the `gtm-qualify-prospects` description no longer capitalises a mid-sentence word, so the routing and description checks pass.
 - `gtm upgrade` also replaces `package-lock.json` from the template. Merging dependencies and regenerating the lockfile locally could drop every platform-specific optional package, after which the Vercel build failed with `Cannot find module '@swc/core-linux-x64-gnu'`.
 
 ## 1.0.2 - 2026-09-11

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -4,6 +4,7 @@ GTM Skills has one project version. Every installable skill ships at that versio
 
 | Project version | Released | Skills | Checked |
 | --- | --- | --- | --- |
+| 1.0.3 | 2026-09-11 | `gtm-workspace`, `gtm-icp`, `gtm-persona`, `gtm-qualify-prospects`, `gtm-workflow` | 2026-09-11 |
 | 1.0.2 | 2026-09-11 | `gtm-workspace`, `gtm-icp`, `gtm-persona`, `gtm-qualify-prospects`, `gtm-workflow` | 2026-09-11 |
 | 1.0.1 | 2026-09-11 | `gtm-workspace`, `gtm-icp`, `gtm-persona`, `gtm-qualify-prospects`, `gtm-workflow` | 2026-09-11 |
 | 1.0.0 | 2026-09-11 | `gtm-workspace`, `gtm-icp`, `gtm-persona`, `gtm-qualify-prospects`, `gtm-workflow` | 2026-09-11 |

--- a/skills/gtm-qualify-prospects/SKILL.md
+++ b/skills/gtm-qualify-prospects/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gtm-qualify-prospects
-description: Triggers when a user asks to qualify, score, or fit-check supplied leads, accounts, contacts, people, or companies in either supported mode, people against a connected GTM workspace's saved personas or companies against its saved ICPs. Includes "is X a fit for us" requests. Not for creating or editing ICPs or personas, saved or scheduled scoring at volume (use gtm-workflow), intent or engagement scoring, or workspace repair.
+description: Triggers when a user asks to qualify, score, or fit-check supplied leads, accounts, contacts, people, or companies in either supported mode, people against a connected GTM workspace's saved personas or companies against its saved ICPs, including "is X a fit for us" requests. Not for creating or editing ICPs or personas, saved or scheduled scoring at volume (use gtm-workflow), intent or engagement scoring, or workspace repair.
 ---
 
 # GTM Qualify Prospects

--- a/skills/gtm-workflow/SKILL.md
+++ b/skills/gtm-workflow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gtm-workflow
-description: Triggers when a user asks to create, update, inspect, delete, run, query, schedule, or deploy a saved GTM workflow. Not for workspace setup, ICP or persona lifecycle work, or one-off work that should not become a reusable workflow.
+description: Triggers when a user asks to create, update, inspect, delete, run, query, schedule, or deploy a saved GTM workflow. Not for workspace setup, ICP or persona lifecycle work, other workflow engines, or one-off calls that are not saved as workflows.
 ---
 
 # GTM workflow


### PR DESCRIPTION
## Why

The Skill compatibility job has failed on every push since the 1.0.0 merge (six runs today). `evals/run_quality.py` routes negative prompts by literal phrases in each skill's "Not for" clause. The 1.0.0 rewrite of the gtm-workflow description dropped "other workflow engines" and "one-off calls", so two core cases fell to 22/24 (threshold 95%). The description lint also flagged the capitalised "Includes" in gtm-qualify-prospects as a possible product name.

## What

- gtm-workflow: `Not for workspace setup, ICP or persona lifecycle work, other workflow engines, or one-off calls that are not saved as workflows.`
- gtm-qualify-prospects: `..., including "is X a fit for us" requests.`
- CHANGELOG and VERSIONS cut 1.0.3, which also carries the lockfile-copying upgrade from #93. Tag `v1.0.3` follows the merge.

## Verified locally with the job's three commands

- `check_skill_compatibility.py`: 5 skills valid.
- `test_skill_compatibility.py`: 2 tests OK.
- `run_quality.py`: 5 descriptions passed, routing core 24/24, hard 8/8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014qiVGRPcpUq6XbE1SNpXC7