### PR TITLE
Keep the workspace-generated migration list on upgrade (1.0.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.0.4 - 2026-09-11
+
+- `gtm upgrade` keeps the workspace's generated `lib/migrations.generated.ts` instead of overwriting it with the template's copy, which listed the template's migrations rather than the workspace's and made the next startup migration fail with a duplicate column.
+- `gtm upgrade` removes its temporary download directory instead of leaving `.gtm-upgrade-*` behind in the workflow project.
+
 ## 1.0.3 - 2026-09-11
 
 - The `gtm-workflow` description names other workflow engines and unsaved one-off calls in its exclusion clause again, and the `gtm-qualify-prospects` description no longer capitalises a mid-sentence word, so the routing and description checks pass.

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -4,6 +4,7 @@ GTM Skills has one project version. Every installable skill ships at that versio
 
 | Project version | Released | Skills | Checked |
 | --- | --- | --- | --- |
+| 1.0.4 | 2026-09-11 | `gtm-workspace`, `gtm-icp`, `gtm-persona`, `gtm-qualify-prospects`, `gtm-workflow` | 2026-09-11 |
 | 1.0.3 | 2026-09-11 | `gtm-workspace`, `gtm-icp`, `gtm-persona`, `gtm-qualify-prospects`, `gtm-workflow` | 2026-09-11 |
 | 1.0.2 | 2026-09-11 | `gtm-workspace`, `gtm-icp`, `gtm-persona`, `gtm-qualify-prospects`, `gtm-workflow` | 2026-09-11 |
 | 1.0.1 | 2026-09-11 | `gtm-workspace`, `gtm-icp`, `gtm-persona`, `gtm-qualify-prospects`, `gtm-workflow` | 2026-09-11 |

--- a/skills/gtm-workflow/templates/lib/cli-helpers.ts
+++ b/skills/gtm-workflow/templates/lib/cli-helpers.ts
@@ -22,3 +22,10 @@ export function backgroundArgv(args: string[]): string[] {
 
 /** Paths `gtm upgrade` replaces from the template. The lockfile is authored content: a regenerated one can drop the platform binaries Linux builds need. */
 export const UPGRADE_REPLACES = ["lib", "server", "scripts", "nitro.config.ts", "drizzle.config.ts", "package-lock.json"] as const;
+
+/** Files under the replaced paths that the workspace generates itself, so upgrade must not copy them from the template. */
+export const UPGRADE_KEEPS = ["lib/migrations.generated.ts"] as const;
+
+export function upgradeCopies(relativePath: string): boolean {
+  return !(UPGRADE_KEEPS as readonly string[]).includes(relativePath.split("\\").join("/"));
+}

--- a/skills/gtm-workflow/templates/scripts/gtm.ts
+++ b/skills/gtm-workflow/templates/scripts/gtm.ts
@@ -1,12 +1,12 @@
 import { spawn } from "node:child_process";
 import { createHash, randomBytes } from "node:crypto";
 import { existsSync } from "node:fs";
-import { cp, mkdir, mkdtemp, readFile, readdir, writeFile } from "node:fs/promises";
+import { cp, mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
 import { createServer } from "node:net";
 import { basename, join, relative, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 import { executeReadOnly, ensureMigrated, readAppliedMigrationHashes } from "../lib/db";
-import { HELP, UPGRADE_REPLACES, backgroundArgv, pendingFrom } from "../lib/cli-helpers";
+import { HELP, UPGRADE_KEEPS, UPGRADE_REPLACES, backgroundArgv, pendingFrom, upgradeCopies } from "../lib/cli-helpers";
 import { ensureRunSecret } from "../lib/local-env";
 import { diagramCost, parseDiagramSpec } from "../lib/diagram-spec";
 import { overlayRun } from "../lib/diagram-overlay";
@@ -122,10 +122,14 @@ async function diagram(args: string[]) {
 
 async function upgrade(args: string[]) {
   const { positionals, flags } = parse(args), ref = positionals[0] ?? "main"; const temporary = await mkdtemp(join(root, ".gtm-upgrade-"));
+  try { await upgradeFrom(ref, flags, temporary); } finally { await rm(temporary, { recursive: true, force: true }); }
+}
+
+async function upgradeFrom(ref: string, flags: Flags, temporary: string) {
   await command("curl", ["-fsSL", `https://github.com/eliasstravik/gtm-skills/archive/${ref}.tar.gz`, "-o", join(temporary, "skills.tgz")]); await command("tar", ["-xzf", join(temporary, "skills.tgz"), "-C", temporary]);
   const sourceRoot = (await walk(temporary, (path) => path.endsWith("/skills/gtm-workflow/templates/package.json")))[0]?.replace(/\/package\.json$/, ""); if (!sourceRoot) throw new AppError("upgrade_failed", "The release does not contain the workflow template.");
-  if (!flags.yes) return print({ ref, replaces: UPGRADE_REPLACES, preserves: ["workflows", "db/tables", "providers", "drizzle", "data", ".env"] });
-  for (const path of UPGRADE_REPLACES) await cp(join(sourceRoot, path), join(root, path), { recursive: true, force: true });
+  if (!flags.yes) return print({ ref, replaces: UPGRADE_REPLACES, keeps: UPGRADE_KEEPS, preserves: ["workflows", "db/tables", "providers", "drizzle", "data", ".env"] });
+  for (const path of UPGRADE_REPLACES) await cp(join(sourceRoot, path), join(root, path), { recursive: true, force: true, filter: (source) => upgradeCopies(relative(sourceRoot, source)) });
   const current = JSON.parse(await readFile(join(root, "package.json"), "utf8")), next = JSON.parse(await readFile(join(sourceRoot, "package.json"), "utf8")); current.dependencies = { ...current.dependencies, ...next.dependencies }; current.devDependencies = { ...current.devDependencies, ...next.devDependencies }; current.gtm = { ...(current.gtm ?? {}), skillsRelease: ref }; await writeFile(join(root, "package.json"), `${JSON.stringify(current, null, 2)}\n`); process.stdout.write("Run npm ci.\n");
 }
 

--- a/tests/cli-helpers.test.mjs
+++ b/tests/cli-helpers.test.mjs
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { HELP, UPGRADE_REPLACES, backgroundArgv, pendingFrom } from '../skills/gtm-workflow/templates/lib/cli-helpers.ts';
+import { HELP, UPGRADE_REPLACES, backgroundArgv, pendingFrom, upgradeCopies } from '../skills/gtm-workflow/templates/lib/cli-helpers.ts';
 
 test('pending migrations are the files whose hash is not in the ledger', () => {
   const files = [{ file: 'drizzle/0000_a.sql', hash: 'h1' }, { file: 'drizzle/0001_b.sql', hash: 'h2' }];
@@ -24,4 +24,10 @@ test('help lists every flag and diagram format', () => {
 test('upgrade replaces the template lockfile so a regenerated one cannot drop platform binaries', () => {
   assert.ok(UPGRADE_REPLACES.includes('package-lock.json'));
   assert.ok(!UPGRADE_REPLACES.includes('package.json'), 'package.json is merged, not replaced');
+});
+
+test('upgrade copies template code but keeps the workspace-generated migration list', () => {
+  assert.equal(upgradeCopies('lib/db.ts'), true);
+  assert.equal(upgradeCopies('scripts/gtm.ts'), true);
+  assert.equal(upgradeCopies('lib/migrations.generated.ts'), false);
 });


### PR DESCRIPTION
## Why

Upgrading gtm-eliasstravik to 1.0.3 replaced `workflows/lib/migrations.generated.ts` (ten workspace migrations, generated by `db:generate` from the workspace's own `drizzle/`) with the template's six, and `gtm check` failed with `SQLITE_ERROR: duplicate column name: cost_source`. `gtm upgrade` copied `lib/` wholesale. It also left `.gtm-upgrade-*` temp directories in the project.

## What

- `upgradeCopies()` filters `lib/migrations.generated.ts` out of the copy; the dry run reports it under `keeps`.
- The temporary download directory is removed in a `finally`.

## Verified

- 128 template tests pass, `tsc` clean.
- End-to-end on a scratch copy of the stravik workspace using this branch's `gtm.ts`: `upgrade <branch> --yes` leaves the migration list byte-identical, updates `lib/db.ts` and the lockfile to the template, updates the pin, and leaves no temp directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014qiVGRPcpUq6XbE1SNpXC7